### PR TITLE
Fix JENKINS-53841

### DIFF
--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddShortTextStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddShortTextStep.java
@@ -100,6 +100,10 @@ public class AddShortTextStep extends Step {
     this.shortText.setLink(link);
   }
 
+  public String getLink() {
+    return this.shortText.getLink();
+  }
+
   @Override
   public StepExecution start(StepContext context) {
     return new Execution(shortText, context);


### PR DESCRIPTION
no public field ‘link’ (or getter method) found in class com.jenkinsci.plugins.badge.dsl.AddShortTextStep