### PR TITLE
Use GitHub for plugins.jenkins.io documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>badge</artifactId>
     <version>1.9-SNAPSHOT</version>
     <packaging>hpi</packaging>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Badge+Plugin</url>
+    <url>https://github.com/jenkinsci/badge-plugin</url>
 
     <developers>
         <developer>


### PR DESCRIPTION
Hacktoberfest contribution to implement [JENKINS-59646](https://issues.jenkins-ci.org/browse/JENKINS-59646) and use GitHub for docs displayed on [plugins.jenkins.io](https://plugins.jenkins.io/badge).  The README already contains excellent documentation, just need this configuration change to use that documentation on plugins.jenkins.io the next time the plugin is released.