### PR TITLE
addShortText step should use the same appearance defaults as manager.…

### DIFF
--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddShortTextStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddShortTextStep.java
@@ -128,10 +128,10 @@ public class AddShortTextStep extends Step {
     private static final long serialVersionUID = 1L;
 
     private final String text;
-    private String color;
-    private String background;
-    private Integer border;
-    private String borderColor;
+    private String color = "#000000";
+    private String background = "#FFFF00";
+    private Integer border = 1;
+    private String borderColor = "#C0C000";
     private String link;
 
     public ShortText(String text) {

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/ShortTextStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/ShortTextStepTest.java
@@ -81,10 +81,10 @@ public class ShortTextStepTest extends AbstractBadgeTest {
 
     BadgeAction action = (BadgeAction) badgeActions.get(0);
     assertEquals(text, action.getText());
-    assertNull(action.getColor());
-    assertNull(action.getBackground());
-    assertNull(action.getBorderColor());
-    assertNull(action.getBorder());
+    assertEquals("#000000", action.getColor());
+    assertEquals("#FFFF00", action.getBackground());
+    assertEquals("#C0C000", action.getBorderColor());
+    assertEquals("1px", action.getBorder());
     assertNull(action.getIconPath());
     assertNull(action.getLink());
   }


### PR DESCRIPTION
The addShortText step adds a badge that does not render in the same fashion as a badge that is added via the manager (i.e. GroovyPostbuildRecorder.BadgeManager); see attached image.

I would expect these two methods for adding text badges would produce identical badges. The fix here is to initialize ShortText with the same defaults used in BadgeAction,

![image](https://user-images.githubusercontent.com/15637253/77776452-6b53a980-7024-11ea-9cb8-46d4cff0142f.png)
