### PR TITLE
makes short text default configurable

### DIFF
--- a/src/main/java/com/jenkinsci/plugins/badge/BadgePlugin.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/BadgePlugin.java
@@ -37,6 +37,8 @@ import org.kohsuke.stapler.StaplerResponse;
 import java.io.IOException;
 import java.util.List;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 @Extension
 public class BadgePlugin extends GlobalConfiguration {
 
@@ -45,7 +47,22 @@ public class BadgePlugin extends GlobalConfiguration {
     return GlobalConfiguration.all().get(BadgePlugin.class);
   }
 
+  /** Default short text color */
+  public static final String SHORT_TEXT_DEFAULT_COLOR = "#000000";
+  /** Default short text background color */
+  public static final String SHORT_TEXT_DEFAULT_BACKGROUND= "#FFFF00";
+  /** Default short border */
+  public static final String SHORT_TEXT_DEFAULT_BORDER = "1px";
+  /** Default short border color */
+  public static final String SHORT_TEXT_DEFAULT_BORDER_COLOR = "#C0C000";
+
   private boolean disableFormatHTML;
+  private String shortTextDefaultColor = SHORT_TEXT_DEFAULT_COLOR;
+  private String shortTextDefaultBackgroundColor = SHORT_TEXT_DEFAULT_BACKGROUND;
+  private String shortTextDefaultBorder = SHORT_TEXT_DEFAULT_BORDER;
+  private String shortTextDefaultBorderColor = SHORT_TEXT_DEFAULT_BORDER_COLOR;
+
+
 
   public BadgePlugin() {
     // When Jenkins is restarted, load any saved configuration from disk.
@@ -66,6 +83,84 @@ public class BadgePlugin extends GlobalConfiguration {
     this.disableFormatHTML = disableFormatHTML;
     save();
   }
+
+  /** @return the default color for short text badges */
+  public String getShortTextDefaultColor() {
+    return shortTextDefaultColor;
+  }
+
+  /**
+   * Together with {@link #getShortTextDefaultColor}, binds to entry in {@code config.jelly}.
+   * @param shortTextDefaultColor the new value of this field
+   */
+  @DataBoundSetter
+  public void setShortTextDefaultColor(String shortTextDefaultColor) {
+    if (isNullOrEmpty(shortTextDefaultColor)) {
+      this.shortTextDefaultColor = SHORT_TEXT_DEFAULT_BACKGROUND;
+    } else {
+      this.shortTextDefaultColor = shortTextDefaultColor;
+    }
+    this.shortTextDefaultColor = shortTextDefaultColor;
+    save();
+  }
+
+  /** @return the default background color for short text badges */
+  public String getShortTextDefaultBackgroundColor() {
+    return shortTextDefaultBackgroundColor;
+  }
+
+  /**
+   * Together with {@link #getShortTextDefaultBackgroundColor}, binds to entry in {@code config.jelly}.
+   * @param shortTextDefaultBackgroundColor the new value of this field
+   */
+  @DataBoundSetter
+  public void setShortTextDefaultBackgroundColor(String shortTextDefaultBackgroundColor) {
+    if (isNullOrEmpty(shortTextDefaultBackgroundColor)) {
+      this.shortTextDefaultBackgroundColor = SHORT_TEXT_DEFAULT_BACKGROUND;
+    } else {
+      this.shortTextDefaultBackgroundColor = shortTextDefaultBackgroundColor;
+    }
+    save();
+  }
+
+  /** @return the default border for short text badges */
+  public String getShortTextDefaultBorder() {
+    return shortTextDefaultBorder;
+  }
+
+  /**
+   * Together with {@link #getShortTextDefaultBorder}, binds to entry in {@code config.jelly}.
+   * @param shortTextDefaultBorder the new value of this field
+   */
+  @DataBoundSetter
+  public void setShortTextDefaultBorder(String shortTextDefaultBorder) {
+    if (isNullOrEmpty(shortTextDefaultBorder)) {
+      this.shortTextDefaultBorder = SHORT_TEXT_DEFAULT_BORDER;
+    } else {
+      this.shortTextDefaultBorder = shortTextDefaultBorder;
+    }
+    save();
+  }
+
+  /** @return the default border color for short text badges */
+  public String getShortTextDefaultBorderColor() {
+    return shortTextDefaultBorderColor;
+  }
+
+  /**
+   * Together with {@link #getShortTextDefaultColor}, binds to entry in {@code config.jelly}.
+   * @param shortTextDefaultBorderColor the new value of this field
+   */
+  @DataBoundSetter
+  public void setShortTextDefaultBorderColor(String shortTextDefaultBorderColor) {
+    if (isNullOrEmpty(shortTextDefaultBorderColor)) {
+      this.shortTextDefaultBorderColor = SHORT_TEXT_DEFAULT_BORDER_COLOR;
+    } else {
+      this.shortTextDefaultBorderColor = shortTextDefaultBorderColor;
+    }
+    save();
+  }
+
 
   public void doRemoveBadges(StaplerRequest req, StaplerResponse rsp) throws IOException {
     removeActions(BadgeAction.class, req, rsp);

--- a/src/main/java/com/jenkinsci/plugins/badge/action/BadgeAction.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/action/BadgeAction.java
@@ -23,6 +23,7 @@
  */
 package com.jenkinsci.plugins.badge.action;
 
+import com.google.common.base.Strings;
 import com.jenkinsci.plugins.badge.BadgePlugin;
 import hudson.PluginWrapper;
 import hudson.model.Hudson;
@@ -35,15 +36,17 @@ import org.kohsuke.stapler.export.ExportedBean;
 
 import java.io.File;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 @ExportedBean(defaultVisibility = 2)
 public class BadgeAction extends AbstractBadgeAction {
   private static final long serialVersionUID = 1L;
   private final String iconPath;
   private final String text;
-  private String color = "#000000";
-  private String background = "#FFFF00";
-  private String border = "1px";
-  private String borderColor = "#C0C000";
+  private String color;
+  private String background;
+  private String border;
+  private String borderColor;
   private String link;
 
   private BadgeAction(String iconPath, String text) {
@@ -72,10 +75,26 @@ public class BadgeAction extends AbstractBadgeAction {
 
   public static BadgeAction createShortText(String text, String color, String background, String border, String borderColor, String link) {
     BadgeAction action = new BadgeAction(null, text);
-    action.color = color;
-    action.background = background;
-    action.border = border;
-    action.borderColor = borderColor;
+    if (isNullOrEmpty(color)) {
+      action.color = BadgePlugin.get().getShortTextDefaultColor();
+    } else {
+      action.color = color;
+    }
+    if (isNullOrEmpty(background)) {
+      action.background = BadgePlugin.get().getShortTextDefaultBackgroundColor();
+    } else {
+      action.background = background;
+    }
+    if (isNullOrEmpty(border)) {
+      action.border = BadgePlugin.get().getShortTextDefaultBorder();
+    } else {
+      action.border = border;
+    }
+    if (isNullOrEmpty(borderColor)) {
+      action.borderColor = BadgePlugin.get().getShortTextDefaultBorderColor();
+    } else {
+      action.borderColor = borderColor;
+    }
     action.link = link;
     return action;
   }

--- a/src/main/resources/com/jenkinsci/plugins/badge/BadgePlugin/config.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/BadgePlugin/config.jelly
@@ -5,5 +5,17 @@
        <f:entry title="Disable OWASP Markup Formatter" description="If checked, HTML content will not be formatted according OWASP in badges.">
          <f:checkbox name="disableFormatHTML" field="disableFormatHTML" default="false" value="${disableFormatHTML}"/>
        </f:entry>
+       <f:entry field="shortTextDefaultColor" title="ShortText default Color">
+           <f:textbox default="${descriptor.SHORT_TEXT_DEFAULT_COLOR}"/>
+       </f:entry>
+       <f:entry field="shortTextDefaultBackgroundColor" title="ShortText default Background">
+           <f:textbox default="${descriptor.SHORT_TEXT_DEFAULT_BACKGROUND}"/>
+       </f:entry>
+       <f:entry field="shortTextDefaultBorder" title="ShortText default Border">
+           <f:textbox default="${descriptor.SHORT_TEXT_DEFAULT_BORDER}"/>
+       </f:entry>
+       <f:entry field="shortTextDefaultBorderColor" title="ShortText default Border Color">
+           <f:textbox default="${descriptor.SHORT_TEXT_DEFAULT_BORDER_COLOR}"/>
+       </f:entry>
     </f:section>
 </j:jelly>

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/ShortTextStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/ShortTextStepTest.java
@@ -23,6 +23,7 @@
  */
 package com.jenkinsci.plugins.badge.dsl;
 
+import com.jenkinsci.plugins.badge.BadgePlugin;
 import com.jenkinsci.plugins.badge.action.BadgeAction;
 import hudson.model.Action;
 import hudson.model.BuildBadgeAction;
@@ -81,10 +82,10 @@ public class ShortTextStepTest extends AbstractBadgeTest {
 
     BadgeAction action = (BadgeAction) badgeActions.get(0);
     assertEquals(text, action.getText());
-    assertNull(action.getColor());
-    assertNull(action.getBackground());
-    assertNull(action.getBorderColor());
-    assertNull(action.getBorder());
+    assertEquals(BadgePlugin.SHORT_TEXT_DEFAULT_COLOR, action.getColor());
+    assertEquals(BadgePlugin.SHORT_TEXT_DEFAULT_BACKGROUND, action.getBackground());
+    assertEquals(BadgePlugin.SHORT_TEXT_DEFAULT_BORDER, action.getBorder());
+    assertEquals(BadgePlugin.SHORT_TEXT_DEFAULT_BORDER_COLOR, action.getBorderColor());
     assertNull(action.getIconPath());
     assertNull(action.getLink());
   }


### PR DESCRIPTION
This is an alternative implementation to PR https://github.com/jenkinsci/badge-plugin/pull/24 which makes it possible to have the default colors configurable.

These defaults could also be used from the groovy postbuild blugin in a separate PR