### PR TITLE
Modernize plugin development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Per https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  target-branch: master
+  reviewers:
+  - bakito
+  - wolfs
+  - beryx
+  labels:
+  - skip-changelog

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to the Badge Plugin
+
+Plugin source code is hosted on [GitHub](https://github.com/jenkinsci/badge-plugin).
+New feature proposals and bug fix proposals should be submitted as
+[GitHub pull requests](https://help.github.com/articles/creating-a-pull-request).
+Your pull request will be evaluated by the [Jenkins job](https://ci.jenkins.io/job/Plugins/job/badge-plugin/).
+
+Before submitting your change, please assure that you've added tests
+which verify your change.
+
+## Code Coverage
+
+Code coverage reporting is available as a maven target.
+Please try to improve code coverage with tests when you submit a pull request.
+* `mvn -P enable-jacoco clean install jacoco:report` to report code coverage
+
+Please don't introduce new spotbugs output.
+* `mvn spotbugs:check` to analyze project using [Spotbugs](https://spotbugs.github.io)
+* `mvn spotbugs:gui` to review report using GUI
+
+## Maintaining the README
+
+The README file samples are created during the maven `prepare-package` phase by the ReadmeGenerator.
+The base template for the generator is `src/test/resources/readme/README.tmpl`.
+
+Update the README with the command:
+* `mvn prepare`
+
+## Security Issues
+
+Follow the [Jenkins project vulnerability reporting instructions](https://jenkins.io/security/reporting/) to report vulnerabilities.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-jenkins-badge-plugin
-=========================
+# Badge plugin
 
-Jenkins plugin to add badges and build summary entries from a pipeline.
+Jenkins plugin to add badges and build summary entries from a Pipeline.
 
 This plugin was forked from the [Groovy Postbuild Plugin](https://github.com/jenkinsci/groovy-postbuild-plugin) which will in future use the API from this plugin.
 
@@ -269,3 +268,7 @@ Other plugin icons can be used by setting the path of the icon within the jenkin
 ```groovy
 addBadge(icon: "/static/8361d0d6/images/16x16/help.png", text: "help")
 ```
+
+## Report an issue
+
+Please report issues and enhancements as a [GitHub issue](https://github.com/jenkinsci/badge-plugin/issues/new/choose).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Jenkins plugin to add badges and build summary entries from a Pipeline.
 
-This plugin was forked from the [Groovy Postbuild Plugin](https://github.com/jenkinsci/groovy-postbuild-plugin) which will in future use the API from this plugin.
+This plugin was forked from the [Groovy Postbuild Plugin](https://plugins.jenkins.io/groovy-postbuild/) which will in future use the API from this plugin.
 
 
 ## addBadge

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>badge</artifactId>
     <version>1.9-SNAPSHOT</version>
     <packaging>hpi</packaging>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Badge+Plugin</url>
+    <url>https://github.com/jenkinsci/badge-plugin</url>
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>antisamy-markup-formatter</artifactId>
-            <version>1.5</version>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
     <properties>
         <jenkins.version>2.289.1</jenkins.version>
         <java.level>8</java.level>
+        <spotbugs.effort>Max</spotbugs.effort>
+        <spotbugs.threshold>Low</spotbugs.threshold>
         <workflow-step-api-plugin.version>2.14</workflow-step-api-plugin.version>
         <workflow-cps-plugin.version>2.45</workflow-cps-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <description>Add Badges for a build and extend the build summary</description>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>badge</artifactId>
-    <version>1.9-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <url>https://github.com/jenkinsci/badge-plugin</url>
 
@@ -38,6 +38,9 @@
     </licenses>
 
     <properties>
+        <revision>1.9</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <gitHubRepo>jenkinsci/badge-plugin</gitHubRepo>
         <jenkins.version>2.289.1</jenkins.version>
         <java.level>8</java.level>
         <spotbugs.effort>Max</spotbugs.effort>
@@ -47,10 +50,10 @@
     </properties>
 
     <scm>
-        <connection>scm:git:https://github.com/jenkinsci/badge-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/badge-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/badge-plugin</url>
-        <tag>HEAD</tag>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
     </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,6 @@
         <java.level>8</java.level>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.threshold>Low</spotbugs.threshold>
-        <workflow-step-api-plugin.version>2.14</workflow-step-api-plugin.version>
-        <workflow-cps-plugin.version>2.45</workflow-cps-plugin.version>
     </properties>
 
     <scm>
@@ -99,22 +97,30 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>1026.vbc102a67c602</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow-step-api-plugin.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.39</version>
         </dependency>
 
         <dependency>
@@ -125,32 +131,27 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${workflow-cps-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow-step-api-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.20</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.2</version>
+        <version>4.31</version>
     </parent>
 
     <name>Badge</name>
@@ -38,7 +38,7 @@
     </licenses>
 
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.289.1</jenkins.version>
         <java.level>8</java.level>
         <workflow-step-api-plugin.version>2.14</workflow-step-api-plugin.version>
         <workflow-cps-plugin.version>2.45</workflow-cps-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     </properties>
 
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/badge-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/badge-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/badge-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/badge-plugin</url>
         <tag>HEAD</tag>

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/CreateSummaryStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/CreateSummaryStepTest.java
@@ -48,7 +48,7 @@ public class CreateSummaryStepTest extends AbstractBadgeTest {
   public void createSummary_html_unescaped() throws Exception {
     String text = randomUUID().toString();
     BadgeSummaryAction action = createSummary("summary.appendText('<li>" + text + "</li>', false)");
-    assertEquals("<li>" + text + "</li>", action.getText());
+    assertEquals("<ul><li>" + text + "</li></ul>", action.getText());
   }
 
   @Test
@@ -56,7 +56,7 @@ public class CreateSummaryStepTest extends AbstractBadgeTest {
     String text = randomUUID().toString();
     String html = "<li>" + text + "</li><script>alert(\"exploit!\");</script>";
     BadgeSummaryAction action = createSummary("summary.appendText('" + html + "', false);");
-    assertEquals("<li>" + text + "</li>", action.getText());
+    assertEquals("<ul><li>" + text + "</li></ul>", action.getText());
     assertEquals(html, action.getRawText());
   }
 
@@ -71,7 +71,7 @@ public class CreateSummaryStepTest extends AbstractBadgeTest {
   public void createSummary_all() throws Exception {
     String text = randomUUID().toString();
     BadgeSummaryAction action = createSummary("summary.appendText('" + text + "', false, true, true, 'grey')");
-    assertEquals("<b><i><font color=\"grey\">" + text + "</font></i></b>", action.getText());
+    assertEquals("<b><i>" + text + "</i></b>", action.getText());
   }
 
   private BadgeSummaryAction createSummary(String script) throws Exception {

--- a/src/test/java/com/jenkinsci/plugins/badge/readme/ReadmeGenerator.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/readme/ReadmeGenerator.java
@@ -1,13 +1,12 @@
 package com.jenkinsci.plugins.badge.readme;
 
-
-import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.Jinjava;
-import org.apache.commons.io.Charsets;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 
 public class ReadmeGenerator {
@@ -16,10 +15,9 @@ public class ReadmeGenerator {
     jinjava.getGlobalContext().registerTag(new ListImagesTag());
     jinjava.getGlobalContext().registerTag(new DescribeStepTag());
 
+    Map<String, Object> context = new HashMap<>();
 
-    Map<String, Object> context = Maps.newHashMap();
-
-    String template = Resources.toString(Resources.getResource("readme/README.tmpl"), Charsets.UTF_8);
+    String template = Resources.toString(Resources.getResource("readme/README.tmpl"), StandardCharsets.UTF_8);
 
     String renderedTemplate = jinjava.render(template, context);
 

--- a/src/test/resources/readme/README.tmpl
+++ b/src/test/resources/readme/README.tmpl
@@ -1,7 +1,6 @@
-jenkins-badge-plugin
-=========================
+# Badge plugin
 
-Jenkins plugin to add badges and build summary entries from a pipeline.
+Jenkins plugin to add badges and build summary entries from a Pipeline.
 
 This plugin was forked from the [Groovy Postbuild Plugin](https://github.com/jenkinsci/groovy-postbuild-plugin) which will in future use the API from this plugin.
 
@@ -96,3 +95,7 @@ Other plugin icons can be used by setting the path of the icon within the jenkin
 ```groovy
 addBadge(icon: "/static/8361d0d6/images/16x16/help.png", text: "help")
 ```
+
+## Report an issue
+
+Please report issues and enhancements as a [GitHub issue](https://github.com/jenkinsci/badge-plugin/issues/new/choose).


### PR DESCRIPTION
## Modernize plugin development

Allow build with Java 11.  Simplify dependency management with the plugin bill of materials.  Allow incremental builds to be deployed for easier testing.

- Use parent pom 4.31
- Use read only URL for SCM connection
- Use GitHub for plugin documentation
- Increase spotbugs effort to detect issues
- Check dependencies with dependabot
- Allow incremental builds to be deployed
- Remove a Guava usage from test and a deprecation
- Simplify dependency management with plugin bom
- Use antisamy-markup-formatter 2.4
- Add CONTRIBUTING file
- Add 'Please report an issue' link to README
