### PR TITLE
Use plugin bom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,5 @@ updates:
       interval: "weekly"
     ignore:
       # newer jinjava versions are incompatible with guava; this is only needed to generate the readme
+      # Ignore dependency until minimum Jenkins version is 2.320 or later
       - dependency-name: "com.hubspot.jinjava:jinjava"

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to the Badge Plugin
+
+Plugin source code is hosted on [GitHub](https://github.com/jenkinsci/badge-plugin).
+New feature proposals and bug fix proposals should be submitted as
+[GitHub pull requests](https://help.github.com/articles/creating-a-pull-request).
+Your pull request will be evaluated by the [Jenkins job](https://ci.jenkins.io/job/Plugins/job/badge-plugin/).
+
+Before submitting your change, please assure that you've added tests
+which verify your change.
+
+## Code Coverage
+
+Code coverage reporting is available as a maven target.
+Please try to improve code coverage with tests when you submit a pull request.
+* `mvn -P enable-jacoco clean install jacoco:report` to report code coverage
+
+Please don't introduce new spotbugs output.
+* `mvn spotbugs:check` to analyze project using [Spotbugs](https://spotbugs.github.io)
+* `mvn spotbugs:gui` to review report using GUI
+
+## Maintaining the README
+
+The README file samples are created during the maven `prepare-package` phase by the ReadmeGenerator.
+The base template for the generator is `src/test/resources/readme/README.tmpl`.
+
+Update the README with the command:
+* `mvn prepare`
+
+## Security Issues
+
+Follow the [Jenkins project vulnerability reporting instructions](https://jenkins.io/security/reporting/) to report vulnerabilities.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ jenkins-badge-plugin
 
 Jenkins plugin to add badges and build summary entries from a pipeline.
 
-This plugin was forked from the [Groovy Postbuild Plugin](https://github.com/jenkinsci/groovy-postbuild-plugin) which will in future use the API from this plugin.
+This plugin was forked from the [Groovy Postbuild Plugin](https://plugins.jenkins.io/groovy-postbuild) which will in future use the API from this plugin.
 
 
 ## addBadge
@@ -276,3 +276,4 @@ The badge plugin uses by default the OWASP Markup Formatter to sanitize the HTML
 Manage Jenkins -> Configure System -> Badge Plugin
 
 ![alt text](src/doc/config.png "Config")
+

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <description>Add Badges for a build and extend the build summary</description>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>badge</artifactId>
-    <version>1.10-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <url>https://github.com/jenkinsci/badge-plugin</url>
 
@@ -39,16 +39,19 @@
 
     <properties>
         <jenkins.version>2.277.4</jenkins.version>
+        <revision>1.10</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <gitHubRepo>jenkinsci/badge-plugin</gitHubRepo>
         <java.level>8</java.level>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.threshold>Low</spotbugs.threshold>
     </properties>
 
     <scm>
-        <connection>scm:git:https://github.com/jenkinsci/badge-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/badge-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/badge-plugin</url>
-        <tag>HEAD</tag>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
     </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -97,22 +97,30 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.277.x</artifactId>
+                <version>991.v88fedb20a115</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.24</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.24</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.78</version>
         </dependency>
 
         <dependency>
@@ -123,32 +131,27 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.94</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.24</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.35</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.42</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.53</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     </properties>
 
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/badge-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/badge-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/badge-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/badge-plugin</url>
         <tag>HEAD</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
     <properties>
         <jenkins.version>2.277.4</jenkins.version>
         <java.level>8</java.level>
+        <spotbugs.effort>Max</spotbugs.effort>
+        <spotbugs.threshold>Low</spotbugs.threshold>
     </properties>
 
     <scm>

--- a/src/test/java/com/jenkinsci/plugins/badge/readme/ReadmeGenerator.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/readme/ReadmeGenerator.java
@@ -1,13 +1,12 @@
 package com.jenkinsci.plugins.badge.readme;
 
-
-import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.Jinjava;
 
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 
 public class ReadmeGenerator {
@@ -16,8 +15,7 @@ public class ReadmeGenerator {
     jinjava.getGlobalContext().registerTag(new ListImagesTag());
     jinjava.getGlobalContext().registerTag(new DescribeStepTag());
 
-
-    Map<String, Object> context = Maps.newHashMap();
+    Map<String, Object> context = new HashMap<>();
 
     String template = Resources.toString(Resources.getResource("readme/README.tmpl"), StandardCharsets.UTF_8);
 

--- a/src/test/resources/readme/README.tmpl
+++ b/src/test/resources/readme/README.tmpl
@@ -3,7 +3,7 @@ jenkins-badge-plugin
 
 Jenkins plugin to add badges and build summary entries from a pipeline.
 
-This plugin was forked from the [Groovy Postbuild Plugin](https://github.com/jenkinsci/groovy-postbuild-plugin) which will in future use the API from this plugin.
+This plugin was forked from the [Groovy Postbuild Plugin](https://plugins.jenkins.io/groovy-postbuild) which will in future use the API from this plugin.
 
 
 ## addBadge


### PR DESCRIPTION
## Simplify dependency management with plugin bom

- Use read only URL for SCM connection
- Increase spotbugs effort to detect issues
- Dependabot limit can be removed after Jenkins 2.320
- Allow incremental builds to be deployed
- Remove a Guava usage from test and a deprecation
- Simplify dependency management with plugin bom
- Add CONTRIBUTING file
- Link to plugins page, not GitHub repo
