### PR TITLE
Require Jenkins 2.346.3 as minimum Jenkins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,10 @@
     </licenses>
 
     <properties>
-        <jenkins.version>2.277.4</jenkins.version>
+        <jenkins.version>2.346.3</jenkins.version>
         <revision>1.10</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/badge-plugin</gitHubRepo>
-        <java.level>8</java.level>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.threshold>Low</spotbugs.threshold>
     </properties>
@@ -100,8 +99,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.277.x</artifactId>
-                <version>991.v88fedb20a115</version>
+                <artifactId>bom-2.346.x</artifactId>
+                <version>1670.v7f165fc7a_079</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
## Require Jenkins 2.346.3 or newer

https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ recommends either 2.332.4 or 2.346.3.

Also removes the `java.level` property because that is no longer required with the most recent parent pom.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
