### PR TITLE
Improve documentation formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ Jenkins plugin to add badges and build summary entries from a pipeline.
 
 This plugin was forked from the [Groovy Postbuild Plugin](https://plugins.jenkins.io/groovy-postbuild) which will in future use the API from this plugin.
 
-
 ## addBadge
 
 This method allows to add build badge icons.
-
 
 ![alt text](src/doc/badge.png "Badge")
 
@@ -22,7 +20,7 @@ This method allows to add build badge icons.
 
 /**
  * minimal params
- * 
+ *
  * icon: The icon for this badge
  * text: The text for this badge
  */
@@ -30,76 +28,76 @@ addBadge(icon: <icon>, text: <text>)
 
 /**
  * all params
- * 
+ *
  * icon: The icon for this badge
  * text: The text for this badge
- * id: (optional) The id for this badge. This id can be used to selectively delete badges.
+ * id: (optional) The id for this badge.
+ * This id can be used to selectively delete badges.
  * link: (optional) The link to be added to this badge
  */
 addBadge(icon: <icon>, text: <text>, id: <id>, link: <link>)
-
 
 // addInfoBadge
 // ------------------------------------------
 
 /**
  * minimal params
- * 
+ *
  * text: The info text for this badge
  */
 addInfoBadge(text: <text>)
 
 /**
  * all params
- * 
+ *
  * text: The info text for this badge
- * id: (optional) The id for this badge. This id can be used to selectively delete badges.
+ * id: (optional) The id for this badge.
+ * This id can be used to selectively delete badges.
  * link: (optional) The link to be added to this badge
  */
 addInfoBadge(text: <text>, id: <id>, link: <link>)
-
 
 // addWarningBadge
 // ------------------------------------------
 
 /**
  * minimal params
- * 
+ *
  * text: The text for this warning badge
  */
 addWarningBadge(text: <text>)
 
 /**
  * all params
- * 
+ *
  * text: The text for this warning badge
- * id: (optional) The id for this badge. This id can be used to selectively delete badges.
+ * id: (optional) The id for this badge.
+ * This id can be used to selectively delete badges.
  * link: (optional) The link to be added to this badge
  */
 addWarningBadge(text: <text>, id: <id>, link: <link>)
-
 
 // addErrorBadge
 // ------------------------------------------
 
 /**
  * minimal params
- * 
+ *
  * text: The text for this error badge
  */
 addErrorBadge(text: <text>)
 
 /**
  * all params
- * 
+ *
  * text: The text for this error badge
- * id: (optional) The id for this badge. This id can be used to selectively delete badges.
+ * id: (optional) The id for this badge.
+ * This id can be used to selectively delete badges.
  * link: (optional) The link to be added to this badge
  */
 addErrorBadge(text: <text>, id: <id>, link: <link>)
 
 ```
-
 
 ## removeBadges
 
@@ -107,20 +105,22 @@ Removes badges
 
 ```groovy
 
-// removes badges. If no id is provided all are removed, otherwise only the badges with a matching id
+// removes badges. If no id is provided, all are removed.
+// If an id is provided, remove badges with the matching id.
 // removeBadges
 // ------------------------------------------
 
 /**
  * minimal params
- * 
+ *
  */
 removeBadges()
 
 /**
  * all params
- * 
- * id: (optional) The id for this badge. This id can be used to selectively delete badges.
+ *
+ * id: (optional) The id for this badge.
+ * This id can be used to selectively delete badges.
  */
 removeBadges(id: <id>)
 
@@ -138,16 +138,17 @@ Puts a badge with custom html
 
 /**
  * minimal params
- * 
+ *
  * html: The html content to be used for this badge
  */
 addHtmlBadge(html: <html>)
 
 /**
  * all params
- * 
+ *
  * html: The html content to be used for this badge
- * id: (optional) The id for this badge. This id can be used to selectively delete badges.
+ * id: (optional) The id for this badge.
+ * This id can be used to selectively delete badges.
  */
 addHtmlBadge(html: <html>, id: <id>)
 
@@ -158,20 +159,22 @@ Removes html badges
 
 ```groovy
 
-// removes html badges. If no id is provided all are removed, otherwise only the badges with a matching id
+// removes html badges. If no id is provided, all are removed.
+// If an id is provided, badges with the matching id are removed.
 // removeHtmlBadges
 // ------------------------------------------
 
 /**
  * minimal params
- * 
+ *
  */
 removeHtmlBadges()
 
 /**
  * all params
- * 
- * id: (optional) The id for this badge. This id can be used to selectively delete badges.
+ *
+ * id: (optional) The id for this badge.
+ * This id can be used to selectively delete badges.
  */
 removeHtmlBadges(id: <id>)
 
@@ -191,14 +194,14 @@ Puts a badge with a short text
 
 /**
  * minimal params
- * 
+ *
  * text: The text to add fot this badge
  */
 addShortText(text: <text>)
 
 /**
  * all params
- * 
+ *
  * text: The text to add fot this badge
  * background: (optional) The background-color for this short text
  * border: (optional) The border width for this short text
@@ -206,7 +209,9 @@ addShortText(text: <text>)
  * color: (optional) The color for this short text
  * link: (optional) The link for this short text
  */
-addShortText(text: <text>, background: <background>, border: <border>, borderColor: <borderColor>, color: <color>, link: <link>)
+addShortText(text: <text>, background: <background>,
+             border: <border>, borderColor: <borderColor>,
+             color: <color>, link: <link>)
 
 ```
 
@@ -216,30 +221,31 @@ Puts a badge with a short text
 
 ![alt text](src/doc/summary.png "Summary")
 
-
 ```groovy
 
-// creates an entry in the build summary page and returns a summary object corresponding to this entry. The icon must be one of the 48x48 icons offered
+// creates an entry in the build summary page and returns a summary
+// object corresponding to this entry. The icon must be one of the 48x48
+// icons offered.
 
 // createSummary
 // ------------------------------------------
 
 /**
  * minimal params
- * 
+ *
  * icon: The icon for this summary
  */
 createSummary(icon: <icon>)
 
 /**
  * all params
- * 
+ *
  * icon: The icon for this summary
- * id: (optional) The id for this badge. This id can be used to selectively delete badges.
+ * id: (optional) The id for this badge.
+ * This id can be used to selectively delete badges.
  * text: (optional) The title text for this summary
  */
 createSummary(icon: <icon>, id: <id>, text: <text>)
-
 
 def summary = createSummary(icon)
 summary.appendText(text, escapeHtml)
@@ -252,7 +258,8 @@ Removes summaries
 
 ```groovy
 
-// removes summaries. If no id is provided all are removed, otherwise only the summaries with a matching id
+// removes summaries. If no id is provided all are removed, otherwise
+// only the summaries with a matching id.
 // removeSummaries
 // ------------------------------------------
 
@@ -272,6 +279,7 @@ removeSummaries(id: <id>)
 ```
 
 ## icons
+
 In addition to the default [16x16](https://github.com/jenkinsci/jenkins/tree/master/war/src/main/webapp/images/16x16) icons offered by Jenkins, badge plugin provides the following icons:
 
 - ![alt text](src/main/webapp/images/completed.gif "completed.gif") completed.gif
@@ -290,6 +298,7 @@ In addition to the default [16x16](https://github.com/jenkinsci/jenkins/tree/mas
 - ![alt text](src/main/webapp/images/yellow.gif "yellow.gif") yellow.gif
 
 ### other plugin icons
+
 Other plugin icons can be used by setting the path of the icon within the jenkins context. Don't forget the leading '/'.
 
 ```groovy
@@ -302,4 +311,3 @@ The badge plugin uses by default the OWASP Markup Formatter to sanitize the HTML
 Manage Jenkins -> Configure System -> Badge Plugin
 
 ![alt text](src/doc/config.png "Config")
-


### PR DESCRIPTION
## Improve documentation formatting

The examples were wider than necessary so that the reader would see a horizontal scroll bar in the examples.  Examples can be word-wrapped comfortably so that the reader does not need to scroll horizontally to see the example.

### Testing done

Reviewed in the GitHub file viewer

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
