### PR TITLE
Move parallel test control to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,14 @@
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(
+  // Run a JVM per core in tests
+  forkCount: '1C',
   // Container agents start faster and are easier to administer
   useContainerAgent: true,
   // Show failures on all configurations
   failFast: false,
-  // Test Java 11 with a recent LTS, Java 17 even more recent
+  // Test Java 11 and Java 17
   configurations: [
-    [platform: 'linux',   jdk: '17', jenkins: '2.375.1'],
+    [platform: 'linux',   jdk: '17'],
     [platform: 'windows', jdk: '11']
   ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -79,15 +79,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkCount>1C</forkCount>
-                    <parallel>all</parallel>
-                    <useUnlimitedThreads>true</useUnlimitedThreads>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## Move parallel test control to Jenkinsfile

Better to leave the control of parallel tests to the developer based on their local machine configuration.  Use parallel tests on ci.jenkins.io running one JVM tests process per core.

### Testing done

Confirmed that tests pass with `forkCount=1C` and without it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
