### PR TITLE
Remove unused commons-validator dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,3 @@ updates:
       - "dependencies"
     schedule:
       interval: "monthly"
-    ignore:
-      - dependency-name: "commons-validator:commons-validator"

--- a/pom.xml
+++ b/pom.xml
@@ -111,11 +111,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-validator</groupId>
-            <artifactId>commons-validator</artifactId>
-            <version>1.5.1</version>
-        </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Remove unused commons-validator dependency

The commons-validator dependency was added in the 1.9.1 release as part of 468a59527a9b906f1790486674b3b6475bf2f4a3, though there seems to have been no references to validator classes in any history of the repository.  It was not includeed in the 1.9 release or any prior releases.

The commons-validator dependency was added to the master branch after the 1.9.1 release as part of 5ca8ab7a3b839c8db1af9ba485754eb81fd6a1e8. There are no references to validator classes in the current source code.

Removing commons-validator reduces the plugin from over 1MB to less than 60KB.  Comparisons are listed below:

```
-rw-rw-r--. 1 mwaite mwaite   54015 Oct 25  2021 ../badge-1.9.hpi
-rw-rw-r--. 1 mwaite mwaite 1135545 Jan 12  2022 ../badge-1.9.1.hpi
-rw-rw-r--. 1 mwaite mwaite   56150 May  4 07:35 target/badge.hpi
```

### Testing done

Automated tests pass.  Will combine with a minimum Jenkins version update and with the Jenkins design library pull request and test interactively to confirm no surprises.  The Jenkins design library pull request is:

* #130

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
