### PR TITLE
Require Jenkins 2.426.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </licenses>
 
     <properties>
-        <jenkins.version>2.401.3</jenkins.version>
+        <jenkins.version>2.426.3</jenkins.version>
         <revision>1.10</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/badge-plugin</gitHubRepo>
@@ -99,8 +99,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.401.x</artifactId>
-                <version>2745.vc7b_fe4c876fa_</version>
+                <artifactId>bom-2.426.x</artifactId>
+                <version>3010.vec758b_8e7da_3</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <scm>
         <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
     </scm>


### PR DESCRIPTION
## Require Jenkins 2.426.3 or newer

[Plugin installation statistics](https://stats.jenkins.io/pluginversions/badge.html) show that 41% of installs of 1.9.1 (released 2 years ago) are already running Jenkins 2.426.3 or newer.

[SECURITY-3314](https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3314) affects Jenkins 2.426.2 and earlier and strongly advises users to upgrade to 2.426.3.

[Choosing a Jenkins baseline](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) recommends either 2.414.3 or 2.426.3 as the Jenkins minimum version.  Reducing the minimum version to 2.414.3 increases the installation percentage from 41% to 50%, but does not help to persuade users that they should upgrade to at least 2.426.3.

Also includes

- Use standard developerConnection URL (git@github.com)

### Testing done

Automated tests passing.  Will combine with other pull requests and perform interactive testing:

* #130
* #131

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
