### PR TITLE
Fix spelling error in README template

### DIFF
--- a/src/test/resources/readme/README.tmpl
+++ b/src/test/resources/readme/README.tmpl
@@ -144,7 +144,7 @@ Short text badges may use additional css color styles.
 ```groovy
 // jenkins palette colors
 addShortText(text: 'ok', color: 'green')
-addShortText(text: 'oj', color: 'jenkins-!-color-green')
+addShortText(text: 'ok', color: 'jenkins-!-color-green')
 
 // jenkins semantic colors
 addShortText(text: 'ok', color: 'success')


### PR DESCRIPTION
## Fix spelling error in README template

The word 'oj' is now 'ok' to be consistent with other examples.

### Testing done

Confirmed that the `mvn clean verify` only made the common changes to the README, without reverting the earlier spelling fix.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
