### PR TITLE
Test getText() with isDisableFormatHTML

### DIFF
--- a/src/test/java/com/jenkinsci/plugins/badge/action/BadgeActionTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/action/BadgeActionTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.jenkinsci.plugins.badge.BadgePlugin;
 import hudson.model.Hudson;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -133,5 +134,23 @@ class BadgeActionTest {
     void createBadgeWithNullLink(@SuppressWarnings("unused") JenkinsRule r) {
         BadgeAction action = BadgeAction.createBadge("info.gif", "Link in badge", null);
         assertNull(action.getLink());
+    }
+
+    @Test
+    void getTextWithHTMLFormatDisabled(@SuppressWarnings("unused") JenkinsRule r) {
+        boolean defaultValue = BadgePlugin.get().isDisableFormatHTML();
+        String expectedText = "Error badge text";
+        String javaScript = "<script>alert('abc');</script>";
+
+        // JavaScript discarded when formatHTML is enabled (the default)
+        BadgeAction action = BadgeAction.createErrorBadge(expectedText + javaScript);
+        assertEquals(expectedText, action.getText());
+
+        // JavaScript retained when formatHTML is disabled
+        BadgePlugin.get().setDisableFormatHTML(true);
+        assertEquals(expectedText + javaScript, action.getText());
+
+        // Restore the default, do not disable HTML formatting
+        BadgePlugin.get().setDisableFormatHTML(defaultValue);
     }
 }

--- a/src/test/java/com/jenkinsci/plugins/badge/action/BadgeActionTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/action/BadgeActionTest.java
@@ -125,9 +125,22 @@ class BadgeActionTest {
 
     @Test
     void createBadgeWithInvalidLink(@SuppressWarnings("unused") JenkinsRule r) {
+        String invalidLink = "invalid-link";
+
+        // Exception thrown for invalid link by default
         assertThrows(IllegalArgumentException.class, () -> {
-            BadgeAction.createBadge("info.gif", "Link in badge", "invalid-link");
+            BadgeAction.createBadge("info.gif", "Link in badge", invalidLink);
         });
+
+        boolean defaultValue = BadgePlugin.get().isDisableFormatHTML();
+
+        // Exception not thrown if HTMl formatting is disabled
+        BadgePlugin.get().setDisableFormatHTML(true);
+        BadgeAction action = BadgeAction.createBadge("info.gif", "Link in badge", invalidLink);
+        assertEquals(invalidLink, action.getLink());
+
+        // Restore the default, do not disable HTML formatting
+        BadgePlugin.get().setDisableFormatHTML(defaultValue);
     }
 
     @Test


### PR DESCRIPTION
## Test getText() with isDisableFormatHTML

Confirm that JavaScript is discarded by default and is available if the formatting is disabled.

### Testing done

Confirmed tests pass with Java 21 on Linux.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
