### PR TITLE
Use size class for all icons, not just symbols

### DIFF
--- a/src/main/java/com/jenkinsci/plugins/badge/action/BadgeAction.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/action/BadgeAction.java
@@ -200,9 +200,7 @@ public class BadgeAction extends AbstractBadgeAction {
      */
     public String getIconClass() {
         List<String> classes = new LinkedList<>();
-        if (isJenkinsSymbolRef(this.iconPath)) {
-            classes.add("icon-sm");
-        }
+        classes.add("icon-sm"); // control icon image size
 
         if (this.color != null) {
             if (this.color.startsWith("jenkins-!-")) {

--- a/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
@@ -32,32 +32,13 @@ THE SOFTWARE.
       <j:set var="badgeStyle" value="${badgeStyle};color: ${it.iconColorStyle};"/>
     </j:if>
 
-    <!-- Symbols do not need height or width -->
-    <j:choose>
-      <j:when test="${it.iconPath.startsWith('symbol-')}">
-        <j:choose>
-          <j:when test="${it.link == null}">
-            <l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" />
-          </j:when>
-          <j:otherwise>
-            <a href="${it.link}"><l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" /></a>
-          </j:otherwise>
-        </j:choose>
-      </j:when>
+    <j:if test="${it.link == null}">
+      <l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" />
+    </j:if>
 
-      <!-- Icons that are not symbols need height and width -->
-      <j:otherwise>
-        <j:choose>
-          <j:when test="${it.link == null}">
-            <l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" height="16" width="16" />
-          </j:when>
-          <j:otherwise>
-            <a href="${it.link}"><l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" height="16" width="16" /></a>
-          </j:otherwise>
-        </j:choose>
-      </j:otherwise>
-    </j:choose>
-
+    <j:if test="${it.link != null}">
+      <a href="${it.link}"><l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" /></a>
+    </j:if>
   </j:if>
 
   <j:if test="${it.iconPath == null}">

--- a/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
@@ -33,26 +33,30 @@ THE SOFTWARE.
     </j:if>
 
     <!-- Symbols do not need height or width -->
-    <j:if test="${it.iconPath.startsWith('symbol-')}">
-      <j:if test="${it.link == null}">
-        <l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" />
-      </j:if>
+    <j:choose>
+      <j:when test="${it.iconPath.startsWith('symbol-')}">
+        <j:choose>
+          <j:when test="${it.link == null}">
+            <l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" />
+          </j:when>
+          <j:otherwise>
+            <a href="${it.link}"><l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" /></a>
+          </j:otherwise>
+        </j:choose>
+      </j:when>
 
-      <j:if test="${it.link != null}">
-        <a href="${it.link}"><l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" /></a>
-      </j:if>
-    </j:if>
-
-    <!-- Icons that are not symbols need height and width -->
-    <j:if test="${!it.iconPath.startsWith('symbol-')}">
-      <j:if test="${it.link == null}">
-        <l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" height="16" width="16" />
-      </j:if>
-
-      <j:if test="${it.link != null}">
-        <a href="${it.link}"><l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" height="16" width="16" /></a>
-      </j:if>
-    </j:if>
+      <!-- Icons that are not symbols need height and width -->
+      <j:otherwise>
+        <j:choose>
+          <j:when test="${it.link == null}">
+            <l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" height="16" width="16" />
+          </j:when>
+          <j:otherwise>
+            <a href="${it.link}"><l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" height="16" width="16" /></a>
+          </j:otherwise>
+        </j:choose>
+      </j:otherwise>
+    </j:choose>
 
   </j:if>
 

--- a/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
     </j:if>
 
     <!-- Symbols do not need height or width -->
-    <j:if test="${it.iconPath.indexOf('symbol-') == 0}">
+    <j:if test="${it.iconPath.startsWith('symbol-')}">
       <j:if test="${it.link == null}">
         <l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" />
       </j:if>
@@ -44,7 +44,7 @@ THE SOFTWARE.
     </j:if>
 
     <!-- Icons that are not symbols need height and width -->
-    <j:if test="${it.iconPath.indexOf('symbol-') != 0}">
+    <j:if test="${!it.iconPath.startsWith('symbol-')}">
       <j:if test="${it.link == null}">
         <l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" height="16" width="16" />
       </j:if>

--- a/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
@@ -32,13 +32,28 @@ THE SOFTWARE.
       <j:set var="badgeStyle" value="${badgeStyle};color: ${it.iconColorStyle};"/>
     </j:if>
 
-    <j:if test="${it.link == null}">
-      <l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" />
+    <!-- Symbols do not need height or width -->
+    <j:if test="${it.iconPath.indexOf('symbol-') == 0}">
+      <j:if test="${it.link == null}">
+        <l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" />
+      </j:if>
+
+      <j:if test="${it.link != null}">
+        <a href="${it.link}"><l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" /></a>
+      </j:if>
     </j:if>
 
-    <j:if test="${it.link != null}">
-      <a href="${it.link}"><l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" /></a>
+    <!-- Icons that are not symbols need height and width -->
+    <j:if test="${it.iconPath.indexOf('symbol-') != 0}">
+      <j:if test="${it.link == null}">
+        <l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" height="16" width="16" />
+      </j:if>
+
+      <j:if test="${it.link != null}">
+        <a href="${it.link}"><l:icon src="${it.iconPath}" class="${it.iconClass}" style="${badgeStyle}" htmlTooltip="${it.text}" height="16" width="16" /></a>
+      </j:if>
     </j:if>
+
   </j:if>
 
   <j:if test="${it.iconPath == null}">

--- a/src/test/java/com/jenkinsci/plugins/badge/action/BadgeActionTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/action/BadgeActionTest.java
@@ -55,7 +55,7 @@ class BadgeActionTest {
     @Test
     void getIconClass(@SuppressWarnings("unused") JenkinsRule r) {
         BadgeAction action = BadgeAction.createBadge("info.gif", "text");
-        assertEquals("", action.getIconClass());
+        assertEquals("icon-sm", action.getIconClass());
         action = BadgeAction.createBadge("symbol-star plugin-ionicons-api", "text");
         assertEquals("icon-sm", action.getIconClass());
         action = BadgeAction.createBadge("symbol-star plugin-ionicons-api", "#000000", "", null);
@@ -63,7 +63,7 @@ class BadgeActionTest {
         action = BadgeAction.createBadge("symbol-star plugin-ionicons-api", "blue", "", null);
         assertEquals("icon-sm jenkins-!-color-blue", action.getIconClass());
         action = BadgeAction.createBadge("/foo/symbol-star.gif", "blue", "", null);
-        assertEquals("jenkins-!-color-blue", action.getIconClass());
+        assertEquals("icon-sm jenkins-!-color-blue", action.getIconClass());
         action = BadgeAction.createBadge("symbol-star plugin-ionicons-api", "jenkins-!-color-red", "", null);
         assertEquals("icon-sm jenkins-!-color-red", action.getIconClass());
         // teal is not in the palette


### PR DESCRIPTION
## Use size class for all icons, not just symbols

Symbols do not require height or width but icons without height and width will render at their original size instead of rendering at the standard size for icons.

Fixes https://github.com/jenkinsci/badge-plugin/issues/148

### Testing done

Confirmed that **before** this change, the following icon renders incorrectly as a 48x48 image:

```
addBadge(icon: '/images/48x48/light-grey.gif', text: 'large icon')
```

Confirmed that **before** this change, the following icon renders correctly:

```
addBadge(icon: 'symbol-star plugin-ionicons-api', text: 'a starred build')
```

Confirmed that **after** this change, the following icon renders correctly as a 16x16 image:

```
addBadge(icon: '/images/48x48/light-grey.gif', text: 'large icon')
```

Confirmed that **after** this change, the following icon renders correctly:

```
addBadge(icon: 'symbol-star plugin-ionicons-api', text: 'a starred build')
```

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
