### PR TITLE
Add configuration as code documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,3 +362,14 @@ Manage Jenkins -> Configure System -> Badge Plugin
 
 ![alt text](src/doc/config.png "Config")
 
+## Configuration as Code Sample
+
+The [configuration as code plugin](https://plugins.jenkins.io/configuration-as-code/) can define the markup formatter configuration for the badge plugin.
+Markup formatter sanitization is enabled by default.
+The configuration as code setup for that default setting is:
+
+```yaml
+security:
+  badgePlugin:
+    disableFormatHTML: false
+```


### PR DESCRIPTION
## Add configuration as code documentation

Provide an example of the default configuration.  Users will see the same thing when they view the configuration of their controller.

This changed in the [1.11 release](https://github.com/jenkinsci/badge-plugin/releases/tag/badge-1.11).  Previously it was listed in the `unclassified` section of configuration as code.  Now it is listed in the security section.

### Testing done

Verified that the configuration example works on [my controller](https://github.com/MarkEWaite/docker-lfs/blob/a4b1a2f4c9237bd8270b5ff7ef65174d5810cf68/ref/configuration-as-code/security.yaml#L8).

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
