### PR TITLE
Hard-code size of icons (#148)

### DIFF
--- a/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
@@ -24,12 +24,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
 
   <j:if test="${it.iconPath != null}">
-    <j:set var="badgeStyle" value=""/>
+    <j:set var="badgeStyle" value="width: 16px; height: 16px;"/>
     <j:if test="${it.iconColorStyle != null}">
-      <j:set var="badgeStyle" value="color: ${it.iconColorStyle};"/>
+      <j:set var="badgeStyle" value="${badgeStyle} color: ${it.iconColorStyle};"/>
     </j:if>
 
     <j:choose>
@@ -43,29 +43,23 @@ THE SOFTWARE.
   </j:if>
 
   <j:if test="${it.iconPath == null}">
-    <j:set var="badgeStyle" value="border: solid"/>
-    <j:set var="badgeClass" value="badge-shortText"/>
+    <j:set var="badgeStyle" value="border: solid;"/>
     <j:if test="${it.border != null}">
-      <j:set var="badgeStyle" value="border: ${it.border} solid ${it.borderColor}"/>
+      <j:set var="badgeStyle" value="border: ${it.border} solid ${it.borderColor};"/>
     </j:if>
-    <j:choose>
-      <j:when test="${it.background == null}">
-        <j:set var="badgeClass" value="${badgeClass} badge-shortText--default-background"/>
-      </j:when>
-      <j:otherwise>
-        <j:set var="badgeStyle" value="${badgeStyle};background: ${it.background}"/>
-      </j:otherwise>
-    </j:choose>
+    <j:if test="${it.background != null}">
+      <j:set var="badgeStyle" value="${badgeStyle} background: ${it.background};"/>
+    </j:if>
     <j:if test="${it.iconColorStyle != null}">
-      <j:set var="badgeStyle" value="${badgeStyle};color: ${it.iconColorStyle};"/>
+      <j:set var="badgeStyle" value="${badgeStyle} color: ${it.iconColorStyle};"/>
     </j:if>
 
     <j:choose>
       <j:when test="${it.link == null}">
-        <span style="${badgeStyle}" class="${it.iconClass} ${badgeClass}">${it.text}</span>
+        <span style="${badgeStyle}" class="${it.iconClass}">${it.text}</span>
       </j:when>
       <j:otherwise>
-        <a href="${it.link}"><span style="${badgeStyle}" class="${it.iconClass} ${badgeClass}">${it.text}</span></a>
+        <a href="${it.link}"><span style="${badgeStyle}" class="${it.iconClass}">${it.text}</span></a>
       </j:otherwise>
     </j:choose>
   </j:if>


### PR DESCRIPTION
Fixes #148 by hard-coding the icon style to include `width: 16px; height: 16px;`

I also removed the no longer existing references to the `badge-shortText` css classes (removed in https://github.com/jenkinsci/badge-plugin/pull/153/) and therefore the usage of `badgeClass` alltogether.
~~Further I changed the "default" css style for text badges to not be `"border: solid"` anymore - I am pretty sure this was not intended.~~

### Testing done

Manually verified badges look as expected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
