### PR TITLE
Add an example on how to use font-awesome in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ More symbols can be referenced by installing additional plugins, such as [font-a
 ```groovy
 addBadge(icon: 'symbol-cube', text: 'a cubed build')
 addBadge(icon: 'symbol-star plugin-ionicons-api', text: 'a starred build')
+addBadge(icon: 'symbol-brands/git plugin-font-awesome-api', text: 'the git logo')
 addBadge(icon: 'symbol-symbolName plugin-yourArtifactId', text: 'another icon build')
 ```
 


### PR DESCRIPTION
The Font Awesome API plugin use folder structure and thus the symbol notation need a `/`

Some examples:
````
symbol-solid/video
symbol-brands/42-group
symbol-regular/address-book
````

As it's a different behavior than the Ionicons API plugin and that's not mentioned anywhere, adding at least one example could be beneficial.