### PR TITLE
Allow fields to be optional in declarative pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,11 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AbstractAddBadgeStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AbstractAddBadgeStep.java
@@ -31,13 +31,14 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Abstract class to add badges.
  */
 public abstract class AbstractAddBadgeStep extends Step {
 
-    private final String id;
+    private String id;
     private String icon;
     private String text;
     private String cssClass;
@@ -53,47 +54,57 @@ public abstract class AbstractAddBadgeStep extends Step {
         this.link = link;
     }
 
-    protected String getId() {
+    @DataBoundSetter
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
         return id;
     }
 
-    protected String getIcon() {
+    public String getIcon() {
         return icon;
     }
 
-    protected void setIcon(String icon) {
+    @DataBoundSetter
+    public void setIcon(String icon) {
         this.icon = icon;
     }
 
-    protected String getText() {
+    public String getText() {
         return text;
     }
 
-    protected void setText(String text) {
+    @DataBoundSetter
+    public void setText(String text) {
         this.text = text;
     }
 
-    protected String getCssClass() {
+    public String getCssClass() {
         return cssClass;
     }
 
-    protected void setCssClass(String cssClass) {
+    @DataBoundSetter
+    public void setCssClass(String cssClass) {
         this.cssClass = cssClass;
     }
 
-    protected String getStyle() {
+    public String getStyle() {
         return style;
     }
 
-    protected void setStyle(String style) {
+    @DataBoundSetter
+    public void setStyle(String style) {
         this.style = style;
     }
 
-    protected String getLink() {
+    public String getLink() {
         return link;
     }
 
-    protected void setLink(String link) {
+    @DataBoundSetter
+    public void setLink(String link) {
         this.link = link;
     }
 

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AbstractRemoveBadgesStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AbstractRemoveBadgesStep.java
@@ -33,19 +33,25 @@ import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Abstract class to remove badges.
  */
 abstract class AbstractRemoveBadgesStep extends Step {
 
-    private final String id;
+    private String id;
 
     protected AbstractRemoveBadgesStep(String id) {
         this.id = id;
     }
 
-    protected String getId() {
+    @DataBoundSetter
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
         return id;
     }
 

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStep.java
@@ -38,7 +38,11 @@ import org.kohsuke.stapler.DataBoundSetter;
 public class AddBadgeStep extends AbstractAddBadgeStep {
 
     @DataBoundConstructor
-    public AddBadgeStep(String id, String icon, String text, String cssClass, String style, String link) {
+    public AddBadgeStep() {
+        this(null, null, null, null, null, null);
+    }
+
+    protected AddBadgeStep(String id, String icon, String text, String cssClass, String style, String link) {
         super(id, icon, text, cssClass, style, link);
     }
 

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStep.java
@@ -37,7 +37,11 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class AddErrorBadgeStep extends AddBadgeStep {
 
     @DataBoundConstructor
-    public AddErrorBadgeStep(String id, String text, String link) {
+    public AddErrorBadgeStep() {
+        this(null, null, null);
+    }
+
+    protected AddErrorBadgeStep(String id, String text, String link) {
         super(id, Ionicons.getIconClassName("remove-circle"), text, null, "color: var(--error-color)", link);
     }
 

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStep.java
@@ -37,7 +37,11 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class AddInfoBadgeStep extends AddBadgeStep {
 
     @DataBoundConstructor
-    public AddInfoBadgeStep(String id, String text, String link) {
+    public AddInfoBadgeStep() {
+        this(null, null, null);
+    }
+
+    protected AddInfoBadgeStep(String id, String text, String link) {
         super(id, Ionicons.getIconClassName("information-circle"), text, null, "color: var(--blue)", link);
     }
 

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddSummaryStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddSummaryStep.java
@@ -36,7 +36,11 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class AddSummaryStep extends AddBadgeStep {
 
     @DataBoundConstructor
-    public AddSummaryStep(String id, String icon, String text, String cssClass, String style, String link) {
+    public AddSummaryStep() {
+        this(null, null, null, null, null, null);
+    }
+
+    protected AddSummaryStep(String id, String icon, String text, String cssClass, String style, String link) {
         super(id, icon, text, cssClass, style, link);
     }
 

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStep.java
@@ -37,7 +37,11 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class AddWarningBadgeStep extends AddBadgeStep {
 
     @DataBoundConstructor
-    public AddWarningBadgeStep(String id, String text, String link) {
+    public AddWarningBadgeStep() {
+        this(null, null, null);
+    }
+
+    protected AddWarningBadgeStep(String id, String text, String link) {
         super(id, Ionicons.getIconClassName("warning"), text, null, "color: var(--warning-color)", link);
     }
 

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/RemoveBadgesStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/RemoveBadgesStep.java
@@ -35,7 +35,11 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class RemoveBadgesStep extends AbstractRemoveBadgesStep {
 
     @DataBoundConstructor
-    public RemoveBadgesStep(String id) {
+    public RemoveBadgesStep() {
+        this(null);
+    }
+
+    protected RemoveBadgesStep(String id) {
         super(id);
     }
 

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/RemoveSummariesStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/RemoveSummariesStep.java
@@ -35,7 +35,11 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class RemoveSummariesStep extends AbstractRemoveBadgesStep {
 
     @DataBoundConstructor
-    public RemoveSummariesStep(String id) {
+    public RemoveSummariesStep() {
+        this(null);
+    }
+
+    protected RemoveSummariesStep(String id) {
         super(id);
     }
 

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AbstractAddBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AbstractAddBadgeStepTest.java
@@ -33,6 +33,9 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 abstract class AbstractAddBadgeStepTest {
 
     @Test
+    abstract void defaultConstructor(@SuppressWarnings("unused") JenkinsRule r);
+
+    @Test
     void id(@SuppressWarnings("unused") JenkinsRule r) {
         AbstractAddBadgeStep step = createStep(null, "icon", "text", "cssClass", "style", "link");
         assertNull(step.getId());

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AbstractRemoveBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AbstractRemoveBadgeStepTest.java
@@ -35,6 +35,9 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 abstract class AbstractRemoveBadgeStepTest {
 
     @Test
+    abstract void defaultConstructor(@SuppressWarnings("unused") JenkinsRule r);
+
+    @Test
     void id(@SuppressWarnings("unused") JenkinsRule r) {
         AbstractRemoveBadgesStep step = createRemoveStep(null);
         assertNull(step.getId());

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStepTest.java
@@ -33,6 +33,18 @@ class AddErrorBadgeStepTest extends AddBadgeStepTest {
 
     @Override
     @Test
+    void defaultConstructor(JenkinsRule r) {
+        AbstractAddBadgeStep step = new AddErrorBadgeStep();
+        assertNull(step.getId());
+        assertEquals("symbol-remove-circle plugin-ionicons-api", step.getIcon());
+        assertNull(step.getText());
+        assertNull(step.getCssClass());
+        assertEquals("color: var(--error-color)", step.getStyle());
+        assertNull(step.getLink());
+    }
+
+    @Override
+    @Test
     void icon(JenkinsRule r) {
         AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link");
         assertEquals("symbol-remove-circle plugin-ionicons-api", step.getIcon());

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStepTest.java
@@ -33,6 +33,18 @@ class AddInfoBadgeStepTest extends AddBadgeStepTest {
 
     @Override
     @Test
+    void defaultConstructor(JenkinsRule r) {
+        AbstractAddBadgeStep step = new AddInfoBadgeStep();
+        assertNull(step.getId());
+        assertEquals("symbol-information-circle plugin-ionicons-api", step.getIcon());
+        assertNull(step.getText());
+        assertNull(step.getCssClass());
+        assertEquals("color: var(--blue)", step.getStyle());
+        assertNull(step.getLink());
+    }
+
+    @Override
+    @Test
     void icon(JenkinsRule r) {
         AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link");
         assertEquals("symbol-information-circle plugin-ionicons-api", step.getIcon());

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddSummaryStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddSummaryStepTest.java
@@ -24,12 +24,27 @@
 package com.jenkinsci.plugins.badge.dsl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.jenkinsci.plugins.badge.action.BadgeSummaryAction;
 import java.util.List;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 class AddSummaryStepTest extends AddBadgeStepTest {
+
+    @Override
+    @Test
+    void defaultConstructor(JenkinsRule r) {
+        AbstractAddBadgeStep step = new AddSummaryStep();
+        assertNull(step.getId());
+        assertNull(step.getIcon());
+        assertNull(step.getText());
+        assertNull(step.getCssClass());
+        assertNull(step.getStyle());
+        assertNull(step.getLink());
+    }
 
     @Override
     protected void assertFields(AbstractAddBadgeStep step, WorkflowRun run) {

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStepTest.java
@@ -33,6 +33,18 @@ class AddWarningBadgeStepTest extends AddBadgeStepTest {
 
     @Override
     @Test
+    void defaultConstructor(JenkinsRule r) {
+        AbstractAddBadgeStep step = new AddWarningBadgeStep();
+        assertNull(step.getId());
+        assertEquals("symbol-warning plugin-ionicons-api", step.getIcon());
+        assertNull(step.getText());
+        assertNull(step.getCssClass());
+        assertEquals("color: var(--warning-color)", step.getStyle());
+        assertNull(step.getLink());
+    }
+
+    @Override
+    @Test
     void icon(@SuppressWarnings("unused") JenkinsRule r) {
         AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link");
         assertEquals("symbol-warning plugin-ionicons-api", step.getIcon());

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/LegacyPipelineTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/LegacyPipelineTest.java
@@ -45,7 +45,7 @@ class LegacyPipelineTest {
 
     @Test
     void color(JenkinsRule r) throws Exception {
-        WorkflowRun run = runJon(r, "addBadge(color: 'red')");
+        WorkflowRun run = runJob(r, "addBadge(color: 'red')");
 
         List<BuildBadgeAction> badgeActions = run.getBadgeActions();
         assertEquals(1, badgeActions.size());
@@ -53,7 +53,7 @@ class LegacyPipelineTest {
         BadgeAction action = (BadgeAction) badgeActions.get(0);
         assertEquals("color: red;", action.getStyle());
 
-        run = runJon(r, "addBadge(color: 'jenkins-!-color-red')");
+        run = runJob(r, "addBadge(color: 'jenkins-!-color-red')");
 
         badgeActions = run.getBadgeActions();
         assertEquals(1, badgeActions.size());
@@ -61,7 +61,7 @@ class LegacyPipelineTest {
         action = (BadgeAction) badgeActions.get(0);
         assertEquals("color: var(--red);", action.getStyle());
 
-        run = runJon(r, "addBadge(color: 'jenkins-!-warning-color')");
+        run = runJob(r, "addBadge(color: 'jenkins-!-warning-color')");
 
         badgeActions = run.getBadgeActions();
         assertEquals(1, badgeActions.size());
@@ -69,7 +69,7 @@ class LegacyPipelineTest {
         action = (BadgeAction) badgeActions.get(0);
         assertEquals("color: var(--warning-color);", action.getStyle());
 
-        run = runJon(r, "addBadge(color: null)");
+        run = runJob(r, "addBadge(color: null)");
 
         badgeActions = run.getBadgeActions();
         assertEquals(1, badgeActions.size());
@@ -80,7 +80,7 @@ class LegacyPipelineTest {
 
     @Test
     void appendText(JenkinsRule r) throws Exception {
-        WorkflowRun run = runJon(r, "createSummary(text: 'Test Text')");
+        WorkflowRun run = runJob(r, "createSummary(text: 'Test Text')");
 
         List<BadgeSummaryAction> actions = run.getActions(BadgeSummaryAction.class);
         assertEquals(1, actions.size());
@@ -88,7 +88,7 @@ class LegacyPipelineTest {
         BadgeSummaryAction action = actions.get(0);
         assertEquals("Test Text", action.getText());
 
-        run = runJon(r, "def summary = createSummary(text: 'Test Text')\n" + "summary.appendText(' More Text', true)");
+        run = runJob(r, "def summary = createSummary(text: 'Test Text')\n" + "summary.appendText(' More Text', true)");
 
         actions = run.getActions(BadgeSummaryAction.class);
         assertEquals(1, actions.size());
@@ -96,7 +96,7 @@ class LegacyPipelineTest {
         action = actions.get(0);
         assertEquals("Test Text More Text", action.getText());
 
-        run = runJon(r, "def summary = createSummary(text: 'Test Text')\n" + "summary.appendText(' More Text', false)");
+        run = runJob(r, "def summary = createSummary(text: 'Test Text')\n" + "summary.appendText(' More Text', false)");
 
         actions = run.getActions(BadgeSummaryAction.class);
         assertEquals(1, actions.size());
@@ -104,7 +104,7 @@ class LegacyPipelineTest {
         action = actions.get(0);
         assertEquals("Test Text More Text", action.getText());
 
-        run = runJon(
+        run = runJob(
                 r,
                 "def summary = createSummary(text: 'Test Text')\n"
                         + "summary.appendText(' More Text', false, false, false, null)");
@@ -116,7 +116,7 @@ class LegacyPipelineTest {
         assertEquals("Test Text More Text", action.getText());
 
         r.jenkins.setMarkupFormatter(RawHtmlMarkupFormatter.INSTANCE);
-        run = runJon(
+        run = runJob(
                 r,
                 "def summary = createSummary(text: 'Test Text')\n"
                         + "summary.appendText(' More Text', true, true, true, 'red')");
@@ -128,7 +128,7 @@ class LegacyPipelineTest {
         assertEquals("Test Text<b><i> More Text</i></b>", action.getText());
     }
 
-    private static WorkflowRun runJon(JenkinsRule r, String script) throws Exception {
+    private static WorkflowRun runJob(JenkinsRule r, String script) throws Exception {
         WorkflowJob project =
                 r.jenkins.createProject(WorkflowJob.class, UUID.randomUUID().toString());
         project.setDefinition(new CpsFlowDefinition(script, true));

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/RemoveSummariesStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/RemoveSummariesStepTest.java
@@ -24,14 +24,24 @@
 package com.jenkinsci.plugins.badge.dsl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.jenkinsci.plugins.badge.action.BadgeSummaryAction;
 import java.util.List;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 class RemoveSummariesStepTest extends RemoveBadgesStepTest {
+
+    @Override
+    @Test
+    void defaultConstructor(JenkinsRule r) {
+        AbstractRemoveBadgesStep step = new RemoveSummariesStep();
+        assertNull(step.getId());
+    }
 
     @Override
     protected void assertActionExists(WorkflowRun run, int expected) {


### PR DESCRIPTION
See #187 

Added `@DataBoundConstructor` and `@DataBoundSetter` as appropriate to allow fields to be optional.

### Testing done
Manually tested with declarative pipeline and also added new tests for it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
