### PR TITLE
Fix pipeline syntax snippet generation (#198)

### DIFF
--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStep.java
@@ -66,6 +66,15 @@ public class AddBadgeStep extends AbstractAddBadgeStep {
         }
     }
 
+    /**
+     * @deprecated replaced by {@link #getStyle()}.
+     */
+    @Deprecated(since = "2.0", forRemoval = true)
+    public String getColor() {
+        // translate new field to color
+        return StringUtils.substringBetween(getStyle(), "color: ", ";");
+    }
+
     @Override
     public StepExecution start(StepContext context) {
         return new Execution(getId(), getIcon(), getText(), getCssClass(), getStyle(), getLink(), context) {

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddHtmlBadgeStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddHtmlBadgeStep.java
@@ -85,6 +85,11 @@ public class AddHtmlBadgeStep extends Step {
         public String getDisplayName() {
             return "Add a HTML Badge";
         }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
     }
 
     @Deprecated(since = "2.0", forRemoval = true)

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddShortTextStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddShortTextStep.java
@@ -121,6 +121,11 @@ public class AddShortTextStep extends Step {
         public String getDisplayName() {
             return "Add Short Text";
         }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
     }
 
     @Deprecated(since = "2.0", forRemoval = true)

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/CreateSummaryStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/CreateSummaryStep.java
@@ -95,6 +95,11 @@ public class CreateSummaryStep extends Step {
         public String getDisplayName() {
             return "Create Summary";
         }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
     }
 
     @Deprecated(since = "2.0", forRemoval = true)

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/RemoveHtmlBadgesStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/RemoveHtmlBadgesStep.java
@@ -76,6 +76,11 @@ public class RemoveHtmlBadgesStep extends Step {
         public String getDisplayName() {
             return "Remove HTML Badges";
         }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
     }
 
     @Override

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddHtmlBadgeStep/help.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddHtmlBadgeStep/help.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        This step has been deprecated and should be replaced by <code>addBadge</code>.
+    </p>
+</div>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddShortTextStep/help.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddShortTextStep/help.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        This step has been deprecated and should be replaced by <code>addBadge</code>.
+    </p>
+</div>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/CreateSummaryStep/help.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/CreateSummaryStep/help.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        This step has been deprecated and should be replaced by <code>addSummary</code>.
+    </p>
+</div>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/RemoveHtmlBadgesStep/help.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/RemoveHtmlBadgesStep/help.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        This step has been deprecated and should be replaced by <code>addBadge</code> and <code>removeBadges</code>.
+    </p>
+</div>

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStepTest.java
@@ -52,6 +52,19 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
     }
 
     @Test
+    @Deprecated(since = "2.0", forRemoval = true)
+    void color(@SuppressWarnings("unused") JenkinsRule r) {
+        AddBadgeStep step = (AddBadgeStep) createStep("id", "icon", "text", "cssClass", null, "link");
+        assertNull(step.getColor());
+
+        step.setColor("");
+        assertEquals("", step.getColor());
+
+        step.setColor("style");
+        assertEquals("style", step.getColor());
+    }
+
+    @Test
     void addInScriptedPipeline(JenkinsRule r) throws Exception {
         AbstractAddBadgeStep step = createStep(
                 UUID.randomUUID().toString(),

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddHtmlBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddHtmlBadgeStepTest.java
@@ -25,6 +25,7 @@ package com.jenkinsci.plugins.badge.dsl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.jenkinsci.plugins.badge.action.HtmlBadgeAction;
 import hudson.markup.RawHtmlMarkupFormatter;
@@ -60,6 +61,12 @@ class AddHtmlBadgeStepTest {
         String html = UUID.randomUUID().toString();
         step = new AddHtmlBadgeStep(html);
         assertEquals(html, step.getHtml());
+    }
+
+    @Test
+    void deprecated(@SuppressWarnings("unused") JenkinsRule r) {
+        AddHtmlBadgeStep step = new AddHtmlBadgeStep(null);
+        assertTrue(step.getDescriptor().isAdvanced());
     }
 
     @Test

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/CreateSummaryStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/CreateSummaryStepTest.java
@@ -74,6 +74,12 @@ class CreateSummaryStepTest {
     }
 
     @Test
+    void deprecated(@SuppressWarnings("unused") JenkinsRule r) {
+        CreateSummaryStep step = new CreateSummaryStep(null);
+        assertTrue(step.getDescriptor().isAdvanced());
+    }
+
+    @Test
     void createSummary_plain(JenkinsRule r) throws Exception {
         String text = randomUUID().toString();
         BadgeSummaryAction action = createSummary(r, "summary.appendText('" + text + "')");

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/RemoveHtmlBadgesStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/RemoveHtmlBadgesStepTest.java
@@ -24,6 +24,7 @@
 package com.jenkinsci.plugins.badge.dsl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.model.BuildBadgeAction;
 import java.util.List;
@@ -61,6 +62,12 @@ class RemoveHtmlBadgesStepTest {
         AddHtmlBadgeStep addStep = createAddStep(badgeId);
         RemoveHtmlBadgesStep removeStep = createRemoveStep(UUID.randomUUID().toString());
         runRemoveJob(r, addStep, removeStep, 1);
+    }
+
+    @Test
+    void deprecated(@SuppressWarnings("unused") JenkinsRule r) {
+        RemoveHtmlBadgesStep removeStep = createRemoveStep(null);
+        assertTrue(removeStep.getDescriptor().isAdvanced());
     }
 
     private static void runRemoveJob(

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/ShortTextStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/ShortTextStepTest.java
@@ -25,6 +25,7 @@ package com.jenkinsci.plugins.badge.dsl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.jenkinsci.plugins.badge.action.BadgeAction;
 import hudson.model.BuildBadgeAction;
@@ -95,6 +96,12 @@ class ShortTextStepTest {
 
         step.setLink("https://jenkins.io");
         assertEquals("https://jenkins.io", step.getLink());
+    }
+
+    @Test
+    void deprecated(@SuppressWarnings("unused") JenkinsRule r) {
+        AddShortTextStep step = new AddShortTextStep(null);
+        assertTrue(step.getDescriptor().isAdvanced());
     }
 
     @Test


### PR DESCRIPTION
Fixes #198 

The deprecated `color` field was missing its getter and caused the snippet generation to fail.
The getter was restored and maps to the new `style` field - similar to the setter.

While at it I also moved the deprecated pipeline steps to the "Advanced / Deprecated" section and added a help text to make users aware of the deprecation and replacement steps.

### Testing done
Manually checked that all pipeline steps generate as expected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue