### PR TITLE
Backwards compatibility for color references

### DIFF
--- a/src/main/java/com/jenkinsci/plugins/badge/action/AbstractBadgeAction.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/action/AbstractBadgeAction.java
@@ -35,6 +35,8 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * An abstract action providing an id amongst other fields to build a badge.
@@ -209,7 +211,7 @@ public abstract class AbstractBadgeAction implements Action, Serializable {
             } else if (color.startsWith("jenkins-!-")) {
                 style += "color: var(--" + color.replaceFirst("jenkins-!-", "") + ");";
             } else {
-                style += "color: " + color + ";";
+                style += "color: " + getJenkinsColorStyle(color) + ";";
             }
         }
         if (!style.isEmpty()) {
@@ -217,5 +219,52 @@ public abstract class AbstractBadgeAction implements Action, Serializable {
         }
 
         return this;
+    }
+
+    /**
+     * Get the Jenkins color style for the given color reference. Returns {@code color} if the color is not a
+     * known Jenkins palette color or semantic color.
+     * @param color color reference
+     * @return jenkins color style variable
+     */
+    @NonNull
+    @Restricted(NoExternalUse.class)
+    public static String getJenkinsColorStyle(@NonNull String color) {
+        String primary = color;
+        if (color.startsWith("light-") && color.length() > 6) {
+            primary = color.substring(6);
+        } else if (color.startsWith("dark-") && color.length() > 5) {
+            primary = color.substring(5);
+        }
+        // https://github.com/jenkinsci/jenkins/blob/master/war/src/main/scss/abstracts/_theme.scss
+        switch (primary) {
+                // palette
+            case "blue":
+            case "brown":
+            case "cyan":
+            case "green":
+            case "indigo":
+            case "orange":
+            case "pink":
+            case "purple":
+            case "red":
+            case "yellow":
+            case "white":
+            case "black":
+                return "var(--" + color + ")";
+                // semantics
+            case "accent":
+            case "text":
+            case "error":
+            case "warning":
+            case "destructive":
+            case "build":
+            case "success":
+            case "danger":
+            case "info":
+                return "var(--" + color + "-color)";
+            default:
+                return color;
+        }
     }
 }

--- a/src/main/java/com/jenkinsci/plugins/badge/action/AbstractBadgeAction.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/action/AbstractBadgeAction.java
@@ -257,9 +257,9 @@ public abstract class AbstractBadgeAction implements Action, Serializable {
             case "text":
             case "error":
             case "warning":
+            case "success":
             case "destructive":
             case "build":
-            case "success":
             case "danger":
             case "info":
                 return "var(--" + color + "-color)";

--- a/src/main/java/com/jenkinsci/plugins/badge/action/AbstractBadgeAction.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/action/AbstractBadgeAction.java
@@ -236,7 +236,7 @@ public abstract class AbstractBadgeAction implements Action, Serializable {
         } else if (color.startsWith("dark-") && color.length() > 5) {
             primary = color.substring(5);
         }
-        // https://github.com/jenkinsci/jenkins/blob/master/war/src/main/scss/abstracts/_theme.scss
+        // https://github.com/jenkinsci/jenkins/blob/master/src/main/scss/abstracts/_theme.scss
         switch (primary) {
                 // palette
             case "blue":

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStep.java
@@ -23,6 +23,7 @@
  */
 package com.jenkinsci.plugins.badge.dsl;
 
+import com.jenkinsci.plugins.badge.action.AbstractBadgeAction;
 import com.jenkinsci.plugins.badge.action.BadgeAction;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -60,7 +61,7 @@ public class AddBadgeStep extends AbstractAddBadgeStep {
             } else if (color.startsWith("jenkins-!-")) {
                 newStyle += "color: var(--" + color.replaceFirst("jenkins-!-", "") + ");";
             } else {
-                newStyle += "color: " + color + ";";
+                newStyle += "color: " + AbstractBadgeAction.getJenkinsColorStyle(color) + ";";
             }
             setStyle(newStyle + StringUtils.defaultString(getStyle()));
         }

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddShortTextStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddShortTextStep.java
@@ -23,6 +23,7 @@
  */
 package com.jenkinsci.plugins.badge.dsl;
 
+import com.jenkinsci.plugins.badge.action.AbstractBadgeAction;
 import com.jenkinsci.plugins.badge.action.BadgeAction;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -220,7 +221,7 @@ public class AddShortTextStep extends Step {
                 } else if (shortText.getColor().startsWith("jenkins-!-")) {
                     style += "color: var(--" + shortText.getColor().replaceFirst("jenkins-!-", "") + ");";
                 } else {
-                    style += "color: " + shortText.getColor() + ";";
+                    style += "color: " + AbstractBadgeAction.getJenkinsColorStyle(shortText.getColor()) + ";";
                 }
             }
 

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/LegacyPipelineTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/LegacyPipelineTest.java
@@ -47,21 +47,35 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 class LegacyPipelineTest {
 
     @Test
-    void color(JenkinsRule r) throws Exception {
-        Stream<List<String>> palette = Stream.of(
-                        "blue", "brown", "cyan", "green", "indigo", "orange", "pink", "purple", "red", "yellow",
-                        "white", "black")
-                .map(c -> Arrays.asList("'" + c + "'", "color: var(--" + c + ");"));
-        Stream<List<String>> semantic = Stream.of(
-                        "accent", "text", "error", "warning", "success", "destructive", "build", "danger", "info")
-                .map(c -> Arrays.asList("'" + c + "'", "color: var(--" + c + "-color);"));
+    void color(JenkinsRule r) {
+        List<String> colors = Arrays.asList(
+                "blue", "brown", "cyan", "green", "indigo", "orange", "pink", "purple", "red", "yellow", "white",
+                "black");
+        Stream<List<String>> palette =
+                colors.stream().map(c -> Arrays.asList("'" + c + "'", "color: var(--" + c + ");"));
+        Stream<List<String>> paletteLight =
+                colors.stream().map(c -> Arrays.asList("'light-" + c + "'", "color: var(--light-" + c + ");"));
+        Stream<List<String>> paletteDark =
+                colors.stream().map(c -> Arrays.asList("'dark-" + c + "'", "color: var(--dark-" + c + ");"));
+
+        List<String> semantics = Arrays.asList(
+                "accent", "text", "error", "warning", "success", "destructive", "build", "danger", "info");
+        Stream<List<String>> semantic =
+                semantics.stream().map(c -> Arrays.asList("'" + c + "'", "color: var(--" + c + "-color);"));
+
         Stream<List<String>> other = Stream.of(
+                Arrays.asList("'light-'", "color: light-;"),
+                Arrays.asList("'dark-'", "color: dark-;"),
                 Arrays.asList("'#ff0000'", "color: #ff0000;"),
                 Arrays.asList("'tortoise'", "color: tortoise;"),
                 Arrays.asList("'jenkins-!-color-red'", "color: var(--red);"),
                 Arrays.asList("'jenkins-!-warning-color'", "color: var(--warning-color);"),
+                Arrays.asList("''", "color: ;"),
                 Arrays.asList("null", null));
+
         assertAll("palette", colorTests(r, palette));
+        assertAll("palette-light", colorTests(r, paletteLight));
+        assertAll("palette-dark", colorTests(r, paletteDark));
         assertAll("semantic", colorTests(r, semantic));
         assertAll("other", colorTests(r, other));
     }

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/LegacyPipelineTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/LegacyPipelineTest.java
@@ -45,13 +45,29 @@ class LegacyPipelineTest {
 
     @Test
     void color(JenkinsRule r) throws Exception {
-        WorkflowRun run = runJob(r, "addBadge(color: 'red')");
+        WorkflowRun run = runJob(r, "addBadge(color: '#ff0000')");
 
         List<BuildBadgeAction> badgeActions = run.getBadgeActions();
         assertEquals(1, badgeActions.size());
 
         BadgeAction action = (BadgeAction) badgeActions.get(0);
-        assertEquals("color: red;", action.getStyle());
+        assertEquals("color: #ff0000;", action.getStyle());
+
+        run = runJob(r, "addBadge(color: 'tortoise')");
+
+        badgeActions = run.getBadgeActions();
+        assertEquals(1, badgeActions.size());
+
+        action = (BadgeAction) badgeActions.get(0);
+        assertEquals("color: tortoise;", action.getStyle());
+
+        run = runJob(r, "addBadge(color: 'red')");
+
+        badgeActions = run.getBadgeActions();
+        assertEquals(1, badgeActions.size());
+
+        action = (BadgeAction) badgeActions.get(0);
+        assertEquals("color: var(--red);", action.getStyle());
 
         run = runJob(r, "addBadge(color: 'jenkins-!-color-red')");
 


### PR DESCRIPTION
This change improves the backwards compatibility for legacy badge color references that are not jenkins color classes. Colors that reference defined jenkins palette or semantic names are converted to their respective css variable references.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
