### PR TITLE
Provide built-in css classes for text badges

### DIFF
--- a/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='false'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
     <j:choose>
         <!-- icon -->
         <j:when test="${it.icon != null &amp;&amp; it.icon != ''}">
@@ -48,6 +48,7 @@ THE SOFTWARE.
         <j:otherwise>
             <!-- text -->
             <j:if test="${it.text != null &amp;&amp; it.text != ''}">
+                <st:adjunct includes="com.jenkinsci.plugins.badge.assets"/>
                 <j:choose>
                     <!-- text with link -->
                     <j:when test="${it.link != null &amp;&amp; it.link != ''}">

--- a/src/main/resources/com/jenkinsci/plugins/badge/assets.css
+++ b/src/main/resources/com/jenkinsci/plugins/badge/assets.css
@@ -1,0 +1,44 @@
+.badge-text--background {
+    display: inline-block;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    padding: 0 0.4rem !important;
+    margin: 0 0.1rem 0 0;
+    text-decoration: none;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    position: relative;
+}
+
+.badge-text--background::before {
+    inset: -0px -0px;
+    border-radius: 6px;
+    background: currentColor;
+    opacity: .2;
+    content: "";
+    position: absolute;
+}
+
+.badge-text--background::after {
+    inset: -5px -0px;
+    box-shadow: 0 0 0 10px currentColor;
+    opacity: 0;
+    content: "";
+    position: absolute;
+}
+
+.badge-text--bordered {
+    display: inline-block;
+    border: 0.1rem solid currentColor;
+    font-size: 0.75rem;
+    font-weight: 500;
+    padding: 0 0.2rem !important;
+    margin: 0 0.1rem 0 0;
+    text-decoration: none;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    position: relative;
+}

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help-cssClass.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help-cssClass.html
@@ -1,4 +1,13 @@
 <div>
-    Optional CSS class for the badge. Classes will be applied to the enclosing <code>&lt;span&gt;</code> of a badge.
-    User can also reference Jenkins built-in CSS classes such as <code>icon-sm</code> - see <a href="https://weekly.ci.jenkins.io/design-library">Jenkins Design Library</a> for more details.
+    <p>
+        Optional CSS class for the badge. Classes will be applied to the enclosing <code>&lt;span&gt;</code> of a badge.
+        User can also reference Jenkins built-in CSS classes such as <code>icon-sm</code> - see <a href="https://weekly.ci.jenkins.io/design-library">Jenkins Design Library</a> for more details.
+    </p>
+    <p>
+        This plugin includes pre-defined CSS classes for text only badges:
+        <ul>
+        <li><code>badge-text--background</code> - Adds colored background with rounded corners.</li>
+        <li><code>badge-text--bordered</code> - Adds border that is the same color as the text.</li>
+        </ul>
+    </p>
 </div>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help.html
@@ -58,4 +58,15 @@
         <pre><code>addBadge icon: 'symbol-bug plugin-ionicons-api', text: 'This is a red bug with a link', style: 'color: red', link: 'https://issues.jenkins.io/browse/JENKINS-59646'</code></pre>
     </p>
 
+    <strong><a id="badge-text-with-css-class">Example: Text badge with CSS styles</a></strong>
+    <p>
+        The following example adds text only badge that uses included CSS styles:
+    <pre><code>
+    // Add shaded background color with rounded corners
+    addBadge text: 'ok', style: 'color: var(--success-color)', cssClass: 'badge-text--background'
+    // Add additional border around badge
+    addBadge text: '1.0.0', cssClass: 'badge-text--background badge-text--bordered'
+    </code></pre>
+    </p>
+
 </div>


### PR DESCRIPTION
Restores stylized text only badges lost in 2.0 refactor. Text only badges (no icon or link) will render with rounded corners and default background color that matches the text color but with some opacity.

Before:
![Screenshot 2024-10-11 at 6 11 16 PM](https://github.com/user-attachments/assets/185b9334-abef-4188-88d8-8a83bfda79c8)

After:
![Screenshot 2024-10-11 at 6 10 16 PM](https://github.com/user-attachments/assets/35bd8918-d03e-4cf7-aa53-49aa82435ded)
![Screenshot 2024-10-11 at 5 53 07 PM](https://github.com/user-attachments/assets/475b8225-705a-414b-9264-43aab4d91c8f)


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
