### PR TITLE
Add `target` attribute to badges and summaries

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -108,7 +108,7 @@ See https://www.jenkins.io/doc/pipeline/steps/badge/#addwarningbadge-add-warning
 ----
 
 // add a badge with a warning icon, text and link
-addWarningBadge(text: 'Houston, we have a problem ...', link: 'https://youtu.be/2Q_ZzBGPdqE')
+addWarningBadge(text: 'Houston, we have a problem ...', link: 'https://youtu.be/2Q_ZzBGPdqE', target: '_blank')
 
 ----
 
@@ -150,7 +150,7 @@ See https://www.jenkins.io/doc/pipeline/steps/badge/#addsummary-add-summary[Jenk
 ----
 
 // add a summary with an icon, text and link
-addSummary(icon: 'symbol-home-outline plugin-ionicons-api', text: 'Test Chamber prepared', link: 'https://jenkins.io')
+addSummary(icon: 'symbol-home-outline plugin-ionicons-api', text: 'Test Chamber prepared', link: 'https://jenkins.io', target: "_blank")
 
 // add another summary with an icon and text
 def summary = addSummary(icon: 'symbol-people-outline plugin-ionicons-api', text: 'Looking for Test Subjects ...')

--- a/src/main/java/com/jenkinsci/plugins/badge/action/AbstractBadgeAction.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/action/AbstractBadgeAction.java
@@ -59,6 +59,7 @@ public abstract class AbstractBadgeAction implements Action, Serializable {
     private String cssClass;
     private String style;
     private String link;
+    private String target;
 
     /**
      * Ctor.
@@ -68,14 +69,33 @@ public abstract class AbstractBadgeAction implements Action, Serializable {
      * @param cssClass the css class for a badge.
      * @param style the css style for a badge.
      * @param link the link for a badge.
+     *
+     * @deprecated Use {@link AbstractBadgeAction#AbstractBadgeAction(String, String, String, String, String, String, String)} instead.
      */
+    @Deprecated(since = "2.8")
     protected AbstractBadgeAction(String id, String icon, String text, String cssClass, String style, String link) {
+        this(id, icon, text, cssClass, style, link, null);
+    }
+
+    /**
+     * Ctor.
+     * @param id the id for a badge. if null, a random uuid will be generated.
+     * @param icon the icon for a badge.
+     * @param text the text for a badge.
+     * @param cssClass the css class for a badge.
+     * @param style the css style for a badge.
+     * @param link the link for a badge.
+     * @param target the link target for a badge.
+     */
+    protected AbstractBadgeAction(
+            String id, String icon, String text, String cssClass, String style, String link, String target) {
         this.id = id != null ? id : UUID.randomUUID().toString();
         this.icon = icon;
         this.text = text;
         this.cssClass = cssClass;
         this.style = style;
         this.link = link;
+        this.target = target;
     }
 
     @Exported
@@ -179,6 +199,17 @@ public abstract class AbstractBadgeAction implements Action, Serializable {
 
         LOGGER.log(Level.WARNING, () -> "Invalid link value: '" + link + "' - ignoring it");
         return null;
+    }
+
+    @Whitelisted
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    @Exported
+    @Whitelisted
+    public String getTarget() {
+        return target;
     }
 
     @Override

--- a/src/main/java/com/jenkinsci/plugins/badge/action/BadgeAction.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/action/BadgeAction.java
@@ -25,33 +25,25 @@ package com.jenkinsci.plugins.badge.action;
 
 import hudson.model.BuildBadgeAction;
 import java.io.Serial;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
-import org.kohsuke.stapler.export.Exported;
 
 /**
  * Common action for badges.
  */
 public class BadgeAction extends AbstractBadgeAction implements BuildBadgeAction {
 
-    private String target;
-
     @Serial
     private static final long serialVersionUID = 1L;
 
-    public BadgeAction(String id, String icon, String text, String cssClass, String style, String link, String target) {
+    /**
+     * @deprecated Use {@link BadgeAction#BadgeAction(String, String, String, String, String, String, String)} instead.
+     */
+    @Deprecated(since = "2.8")
+    public BadgeAction(String id, String icon, String text, String cssClass, String style, String link) {
         super(id, icon, text, cssClass, style, link);
-        this.target = target;
     }
 
-    @Whitelisted
-    public void setTarget(String target) {
-        this.target = target;
-    }
-
-    @Exported
-    @Whitelisted
-    public String getTarget() {
-        return target;
+    public BadgeAction(String id, String icon, String text, String cssClass, String style, String link, String target) {
+        super(id, icon, text, cssClass, style, link, target);
     }
 
     @Override

--- a/src/main/java/com/jenkinsci/plugins/badge/action/BadgeAction.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/action/BadgeAction.java
@@ -25,17 +25,33 @@ package com.jenkinsci.plugins.badge.action;
 
 import hudson.model.BuildBadgeAction;
 import java.io.Serial;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.kohsuke.stapler.export.Exported;
 
 /**
  * Common action for badges.
  */
 public class BadgeAction extends AbstractBadgeAction implements BuildBadgeAction {
 
+    private String target;
+
     @Serial
     private static final long serialVersionUID = 1L;
 
-    public BadgeAction(String id, String icon, String text, String cssClass, String style, String link) {
+    public BadgeAction(String id, String icon, String text, String cssClass, String style, String link, String target) {
         super(id, icon, text, cssClass, style, link);
+        this.target = target;
+    }
+
+    @Whitelisted
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    @Exported
+    @Whitelisted
+    public String getTarget() {
+        return target;
     }
 
     @Override

--- a/src/main/java/com/jenkinsci/plugins/badge/action/BadgeSummaryAction.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/action/BadgeSummaryAction.java
@@ -41,9 +41,17 @@ public class BadgeSummaryAction extends AbstractBadgeAction {
 
     private static final Logger LOGGER = Logger.getLogger(BadgeSummaryAction.class.getName());
 
+    /**
+     * @deprecated Use {@link BadgeSummaryAction#BadgeSummaryAction(String, String, String, String, String, String, String)} instead.
+     */
+    @Deprecated
+    public BadgeSummaryAction(String id, String icon, String text, String cssClass, String style, String link) {
+        super(id, icon, text, cssClass, style, link);
+    }
+
     public BadgeSummaryAction(
             String id, String icon, String text, String cssClass, String style, String link, String target) {
-        super(id, icon, text, cssClass, style, link);
+        super(id, icon, text, cssClass, style, link, target);
     }
 
     @Whitelisted

--- a/src/main/java/com/jenkinsci/plugins/badge/action/BadgeSummaryAction.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/action/BadgeSummaryAction.java
@@ -41,7 +41,8 @@ public class BadgeSummaryAction extends AbstractBadgeAction {
 
     private static final Logger LOGGER = Logger.getLogger(BadgeSummaryAction.class.getName());
 
-    public BadgeSummaryAction(String id, String icon, String text, String cssClass, String style, String link) {
+    public BadgeSummaryAction(
+            String id, String icon, String text, String cssClass, String style, String link, String target) {
         super(id, icon, text, cssClass, style, link);
     }
 

--- a/src/main/java/com/jenkinsci/plugins/badge/action/BadgeSummaryAction.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/action/BadgeSummaryAction.java
@@ -24,9 +24,6 @@
 package com.jenkinsci.plugins.badge.action;
 
 import java.io.Serial;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
@@ -39,12 +36,10 @@ public class BadgeSummaryAction extends AbstractBadgeAction {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private static final Logger LOGGER = Logger.getLogger(BadgeSummaryAction.class.getName());
-
     /**
      * @deprecated Use {@link BadgeSummaryAction#BadgeSummaryAction(String, String, String, String, String, String, String)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "2.8")
     public BadgeSummaryAction(String id, String icon, String text, String cssClass, String style, String link) {
         super(id, icon, text, cssClass, style, link);
     }
@@ -52,19 +47,6 @@ public class BadgeSummaryAction extends AbstractBadgeAction {
     public BadgeSummaryAction(
             String id, String icon, String text, String cssClass, String style, String link, String target) {
         super(id, icon, text, cssClass, style, link, target);
-    }
-
-    @Whitelisted
-    @Override
-    public String getIcon() {
-        String icon = super.getIcon();
-
-        if (StringUtils.isBlank(icon)) {
-            LOGGER.log(Level.WARNING, () -> "Invalid icon value: '" + icon + "' - using empty icon instead");
-            return Jenkins.RESOURCE_PATH + "/images/16x16/empty.png";
-        }
-
-        return icon;
     }
 
     @Override

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AbstractAddBadgeStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AbstractAddBadgeStep.java
@@ -45,14 +45,17 @@ public abstract class AbstractAddBadgeStep extends Step {
     private String cssClass;
     private String style;
     private String link;
+    private String target;
 
-    protected AbstractAddBadgeStep(String id, String icon, String text, String cssClass, String style, String link) {
+    protected AbstractAddBadgeStep(
+            String id, String icon, String text, String cssClass, String style, String link, String target) {
         this.id = id;
         this.icon = icon;
         this.text = text;
         this.cssClass = cssClass;
         this.style = style;
         this.link = link;
+        this.target = target;
     }
 
     @DataBoundSetter
@@ -109,6 +112,15 @@ public abstract class AbstractAddBadgeStep extends Step {
         this.link = link;
     }
 
+    public String getTarget() {
+        return target;
+    }
+
+    @DataBoundSetter
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
     @Override
     public String toString() {
         List<String> fields = new ArrayList<>();
@@ -131,7 +143,9 @@ public abstract class AbstractAddBadgeStep extends Step {
         if (getLink() != null) {
             fields.add("link: '" + getLink() + "'");
         }
-
+        if (getTarget() != null) {
+            fields.add("target: '" + getTarget() + "'");
+        }
         return getDescriptor().getFunctionName() + "(" + StringUtils.join(fields, ", ") + ")";
     }
 
@@ -146,9 +160,17 @@ public abstract class AbstractAddBadgeStep extends Step {
         private final String cssClass;
         private final String style;
         private final String link;
+        private final String target;
 
         Execution(
-                String id, String icon, String text, String cssClass, String style, String link, StepContext context) {
+                String id,
+                String icon,
+                String text,
+                String cssClass,
+                String style,
+                String link,
+                String target,
+                StepContext context) {
             super(context);
             this.id = id;
             this.icon = icon;
@@ -156,16 +178,17 @@ public abstract class AbstractAddBadgeStep extends Step {
             this.cssClass = cssClass;
             this.style = style;
             this.link = link;
+            this.target = target;
         }
 
         @Override
         protected AbstractBadgeAction run() throws Exception {
-            AbstractBadgeAction action = newAction(id, icon, text, cssClass, style, link);
+            AbstractBadgeAction action = newAction(id, icon, text, cssClass, style, link, target);
             getContext().get(Run.class).addAction(action);
             return action;
         }
 
         protected abstract AbstractBadgeAction newAction(
-                String id, String icon, String text, String cssClass, String style, String link);
+                String id, String icon, String text, String cssClass, String style, String link, String target);
     }
 }

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStep.java
@@ -40,11 +40,12 @@ public class AddBadgeStep extends AbstractAddBadgeStep {
 
     @DataBoundConstructor
     public AddBadgeStep() {
-        this(null, null, null, null, null, null);
+        this(null, null, null, null, null, null, null);
     }
 
-    protected AddBadgeStep(String id, String icon, String text, String cssClass, String style, String link) {
-        super(id, icon, text, cssClass, style, link);
+    protected AddBadgeStep(
+            String id, String icon, String text, String cssClass, String style, String link, String target) {
+        super(id, icon, text, cssClass, style, link, target);
     }
 
     /**
@@ -78,12 +79,13 @@ public class AddBadgeStep extends AbstractAddBadgeStep {
 
     @Override
     public StepExecution start(StepContext context) {
-        return new Execution(getId(), getIcon(), getText(), getCssClass(), getStyle(), getLink(), context) {
+        return new Execution(
+                getId(), getIcon(), getText(), getCssClass(), getStyle(), getLink(), getTarget(), context) {
 
             @Override
             protected BadgeAction newAction(
-                    String id, String icon, String text, String cssClass, String style, String link) {
-                return new BadgeAction(id, icon, text, cssClass, style, link);
+                    String id, String icon, String text, String cssClass, String style, String link, String target) {
+                return new BadgeAction(id, icon, text, cssClass, style, link, target);
             }
         };
     }

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStep.java
@@ -38,11 +38,11 @@ public class AddErrorBadgeStep extends AddBadgeStep {
 
     @DataBoundConstructor
     public AddErrorBadgeStep() {
-        this(null, null, null);
+        this(null, null, null, null);
     }
 
-    protected AddErrorBadgeStep(String id, String text, String link) {
-        super(id, Ionicons.getIconClassName("remove-circle"), text, null, "color: var(--error-color)", link);
+    protected AddErrorBadgeStep(String id, String text, String link, String target) {
+        super(id, Ionicons.getIconClassName("remove-circle"), text, null, "color: var(--error-color)", link, target);
     }
 
     @Override
@@ -57,6 +57,9 @@ public class AddErrorBadgeStep extends AddBadgeStep {
         }
         if (getLink() != null) {
             fields.add("link: '" + getLink() + "'");
+        }
+        if (getTarget() != null) {
+            fields.add("target: '" + getTarget() + "'");
         }
 
         return getDescriptor().getFunctionName() + "(" + StringUtils.join(fields, ", ") + ")";

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStep.java
@@ -38,11 +38,11 @@ public class AddInfoBadgeStep extends AddBadgeStep {
 
     @DataBoundConstructor
     public AddInfoBadgeStep() {
-        this(null, null, null);
+        this(null, null, null, null);
     }
 
-    protected AddInfoBadgeStep(String id, String text, String link) {
-        super(id, Ionicons.getIconClassName("information-circle"), text, null, "color: var(--blue)", link);
+    protected AddInfoBadgeStep(String id, String text, String link, String target) {
+        super(id, Ionicons.getIconClassName("information-circle"), text, null, "color: var(--blue)", link, target);
     }
 
     @Override
@@ -57,6 +57,9 @@ public class AddInfoBadgeStep extends AddBadgeStep {
         }
         if (getLink() != null) {
             fields.add("link: '" + getLink() + "'");
+        }
+        if (getTarget() != null) {
+            fields.add("target: '" + getTarget() + "'");
         }
 
         return getDescriptor().getFunctionName() + "(" + StringUtils.join(fields, ", ") + ")";

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddShortTextStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddShortTextStep.java
@@ -228,7 +228,8 @@ public class AddShortTextStep extends Step {
                 }
             }
 
-            BadgeAction action = new BadgeAction(null, null, shortText.getText(), null, style, shortText.getLink());
+            BadgeAction action =
+                    new BadgeAction(null, null, shortText.getText(), null, style, shortText.getLink(), null);
             getContext().get(Run.class).addAction(action);
 
             TaskListener listener = getContext().get(TaskListener.class);

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddSummaryStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddSummaryStep.java
@@ -41,17 +41,18 @@ public class AddSummaryStep extends AddBadgeStep {
     }
 
     protected AddSummaryStep(String id, String icon, String text, String cssClass, String style, String link) {
-        super(id, icon, text, cssClass, style, link);
+        super(id, icon, text, cssClass, style, link, null);
     }
 
     @Override
     public StepExecution start(StepContext context) {
-        return new Execution(getId(), getIcon(), getText(), getCssClass(), getStyle(), getLink(), context) {
+        return new Execution(
+                getId(), getIcon(), getText(), getCssClass(), getStyle(), getLink(), getTarget(), context) {
 
             @Override
             protected BadgeSummaryAction newAction(
-                    String id, String icon, String text, String cssClass, String style, String link) {
-                return new BadgeSummaryAction(id, icon, text, cssClass, style, link);
+                    String id, String icon, String text, String cssClass, String style, String link, String target) {
+                return new BadgeSummaryAction(id, icon, text, cssClass, style, link, target);
             }
         };
     }

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddSummaryStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddSummaryStep.java
@@ -37,11 +37,12 @@ public class AddSummaryStep extends AddBadgeStep {
 
     @DataBoundConstructor
     public AddSummaryStep() {
-        this(null, null, null, null, null, null);
+        this(null, null, null, null, null, null, null);
     }
 
-    protected AddSummaryStep(String id, String icon, String text, String cssClass, String style, String link) {
-        super(id, icon, text, cssClass, style, link, null);
+    protected AddSummaryStep(
+            String id, String icon, String text, String cssClass, String style, String link, String target) {
+        super(id, icon, text, cssClass, style, link, target);
     }
 
     @Override

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStep.java
@@ -38,11 +38,11 @@ public class AddWarningBadgeStep extends AddBadgeStep {
 
     @DataBoundConstructor
     public AddWarningBadgeStep() {
-        this(null, null, null);
+        this(null, null, null, null);
     }
 
-    protected AddWarningBadgeStep(String id, String text, String link) {
-        super(id, Ionicons.getIconClassName("warning"), text, null, "color: var(--warning-color)", link);
+    protected AddWarningBadgeStep(String id, String text, String link, String target) {
+        super(id, Ionicons.getIconClassName("warning"), text, null, "color: var(--warning-color)", link, target);
     }
 
     @Override
@@ -57,6 +57,9 @@ public class AddWarningBadgeStep extends AddBadgeStep {
         }
         if (getLink() != null) {
             fields.add("link: '" + getLink() + "'");
+        }
+        if (getTarget() != null) {
+            fields.add("target: '" + getTarget() + "'");
         }
 
         return getDescriptor().getFunctionName() + "(" + StringUtils.join(fields, ", ") + ")";

--- a/src/main/java/com/jenkinsci/plugins/badge/dsl/CreateSummaryStep.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/dsl/CreateSummaryStep.java
@@ -122,7 +122,7 @@ public class CreateSummaryStep extends Step {
 
         @Override
         protected BadgeSummaryAction run() throws Exception {
-            BadgeSummaryAction action = new BadgeSummaryAction(id, icon, null, null, null, null);
+            BadgeSummaryAction action = new BadgeSummaryAction(id, icon, null, null, null, null, null);
             if (StringUtils.isNotBlank(text)) {
                 action.appendText(text);
             }

--- a/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
@@ -25,12 +25,13 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='false'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
+    <st:adjunct includes="com.jenkinsci.plugins.badge.assets"/>
     <j:choose>
         <!-- icon -->
-        <j:when test="${it.icon != null &amp;&amp; it.icon != ''}">
+        <j:when test="${not empty it.icon}">
             <j:choose>
                 <!-- icon with link -->
-                <j:when test="${it.link != null &amp;&amp; it.link != ''}">
+                <j:when test="${not empty it.link}">
                     <span>
                         <a href="${it.link}" target="${it.target}" class="${it.cssClass}" style="${it.style}">
                             <l:icon class="icon-sm" style="width: 16px; height: 16px;" src="${it.icon}" alt="${it.text}" htmlTooltip="${it.text}"/>
@@ -47,11 +48,10 @@ THE SOFTWARE.
         </j:when>
         <j:otherwise>
             <!-- text -->
-            <j:if test="${it.text != null &amp;&amp; it.text != ''}">
-                <st:adjunct includes="com.jenkinsci.plugins.badge.assets"/>
+            <j:if test="${not empty it.text}">
                 <j:choose>
                     <!-- text with link -->
-                    <j:when test="${it.link != null &amp;&amp; it.link != ''}">
+                    <j:when test="${not empty it.link}">
                         <span>
                             <a href="${it.link}" target="${it.target}" class="${it.cssClass}" style="${it.style}">
                                 ${it.text}

--- a/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeAction/badge.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
                 <!-- icon with link -->
                 <j:when test="${it.link != null &amp;&amp; it.link != ''}">
                     <span>
-                        <a href="${it.link}" class="${it.cssClass}" style="${it.style}">
+                        <a href="${it.link}" target="${it.target}" class="${it.cssClass}" style="${it.style}">
                             <l:icon class="icon-sm" style="width: 16px; height: 16px;" src="${it.icon}" alt="${it.text}" htmlTooltip="${it.text}"/>
                         </a>
                     </span>
@@ -53,7 +53,7 @@ THE SOFTWARE.
                     <!-- text with link -->
                     <j:when test="${it.link != null &amp;&amp; it.link != ''}">
                         <span>
-                            <a href="${it.link}" class="${it.cssClass}" style="${it.style}">
+                            <a href="${it.link}" target="${it.target}" class="${it.cssClass}" style="${it.style}">
                                 ${it.text}
                             </a>
                         </span>

--- a/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeSummaryAction/summary.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/action/BadgeSummaryAction/summary.jelly
@@ -24,10 +24,38 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='false'?>
-<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson">
-    <t:summary icon="${it.icon}" href="${it.link}">
-        <span class="${it.cssClass}" style="${it.style}">
-            ${it.text}
-        </span>
-    </t:summary>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
+    <st:adjunct includes="com.jenkinsci.plugins.badge.assets"/>
+    <tr class="app-summary">
+        <td>
+            <j:choose>
+                <!-- with icon -->
+                <j:when test="${not empty it.icon}">
+                    <l:icon src="${it.icon}"/>
+                </j:when>
+                <!-- without icon -->
+                <j:otherwise>
+                    <l:icon src="/images/16x16/empty.png"/>
+                </j:otherwise>
+            </j:choose>
+        </td>
+        <td style="vertical-align:middle">
+            <j:choose>
+                <!-- text with link -->
+                <j:when test="${not empty it.link}">
+                    <a href="${it.link}" target="${it.target}" class="${it.cssClass}" style="${it.style}">
+                        <span>
+                            ${it.text}
+                        </span>
+                    </a>
+                </j:when>
+                <!-- text without link -->
+                <j:otherwise>
+                    <span class="${it.cssClass}" style="${it.style}">
+                        ${it.text}
+                    </span>
+                </j:otherwise>
+            </j:choose>
+        </td>
+    </tr>
 </j:jelly>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/config.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/config.jelly
@@ -43,4 +43,7 @@ THE SOFTWARE.
     <f:entry field="link" title="Link">
         <f:textbox/>
     </f:entry>
+    <f:entry field="target" title="Target">
+        <f:textbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help-target.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help-target.html
@@ -1,0 +1,3 @@
+<div>
+    Optional target frame that is used when http link is opened.
+</div>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help.html
@@ -55,7 +55,7 @@
     <strong><a id="badge-with-red-bug-and-link">Example: Badge with red bug symbol</a></strong>
     <p>
         The following example adds a red bug symbol with the text, "This is a red bug with a link", and a link:
-        <pre><code>addBadge icon: 'symbol-bug plugin-ionicons-api', text: 'This is a red bug with a link', style: 'color: red', link: 'https://issues.jenkins.io/browse/JENKINS-59646', target: 'bugzilla'</code></pre>
+        <pre><code>addBadge icon: 'symbol-bug plugin-ionicons-api', text: 'This is a red bug with a link', style: 'color: red', link: 'https://issues.jenkins.io/browse/JENKINS-59646', target: '_blank'</code></pre>
     </p>
 
     <strong><a id="badge-text-with-css-class">Example: Text badge with CSS styles</a></strong>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help.html
@@ -55,7 +55,7 @@
     <strong><a id="badge-with-red-bug-and-link">Example: Badge with red bug symbol</a></strong>
     <p>
         The following example adds a red bug symbol with the text, "This is a red bug with a link", and a link:
-        <pre><code>addBadge icon: 'symbol-bug plugin-ionicons-api', text: 'This is a red bug with a link', style: 'color: red', link: 'https://issues.jenkins.io/browse/JENKINS-59646'</code></pre>
+        <pre><code>addBadge icon: 'symbol-bug plugin-ionicons-api', text: 'This is a red bug with a link', style: 'color: red', link: 'https://issues.jenkins.io/browse/JENKINS-59646', target: 'bugzilla'</code></pre>
     </p>
 
     <strong><a id="badge-text-with-css-class">Example: Text badge with CSS styles</a></strong>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStep/config.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStep/config.jelly
@@ -34,4 +34,7 @@ THE SOFTWARE.
     <f:entry field="link" title="Link">
         <f:textbox/>
     </f:entry>
+    <f:entry field="target" title="Target">
+        <f:textbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStep/help-target.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStep/help-target.html
@@ -1,0 +1,3 @@
+<div>
+    Optional target frame that is used when http link is opened.
+</div>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStep/help.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStep/help.html
@@ -15,6 +15,6 @@
     <strong><a id="badge-with-text-and-link">Example: Badge with text and link</a></strong>
     <p>
         The following example adds an error badge with the text, "This is alarming" and a link:
-        <pre><code>addErrorBadge text: 'This is alarming', link: 'https://issues.jenkins.io/browse/JENKINS-59646'</code></pre>
+        <pre><code>addErrorBadge text: 'This is alarming', link: 'https://issues.jenkins.io/browse/JENKINS-59646', target: '_blank'</code></pre>
     </p>
 </div>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStep/config.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStep/config.jelly
@@ -34,4 +34,7 @@ THE SOFTWARE.
     <f:entry field="link" title="Link">
         <f:textbox/>
     </f:entry>
+    <f:entry field="target" title="Target">
+        <f:textbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStep/help-target.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStep/help-target.html
@@ -1,0 +1,3 @@
+<div>
+    Optional target frame that is used when http link is opened.
+</div>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStep/help.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStep/help.html
@@ -15,6 +15,6 @@
     <strong><a id="badge-with-text-and-link">Example: Badge with text and link</a></strong>
     <p>
         The following example adds an info badge with the text, "This is interesting" and a link:
-        <pre><code>addInfoBadge text: 'This is interesting', link: 'https://plugins.jenkins.io/custom-folder-icon'</code></pre>
+        <pre><code>addInfoBadge text: 'This is interesting', link: 'https://plugins.jenkins.io/custom-folder-icon', target: '_blank'</code></pre>
     </p>
 </div>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddSummaryStep/config.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddSummaryStep/config.jelly
@@ -43,4 +43,7 @@ THE SOFTWARE.
     <f:entry field="link" title="Link">
         <f:textbox/>
     </f:entry>
+    <f:entry field="target" title="Target">
+        <f:textbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddSummaryStep/help-target.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddSummaryStep/help-target.html
@@ -1,0 +1,3 @@
+<div>
+    Optional target frame that is used when http link is opened.
+</div>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddSummaryStep/help.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddSummaryStep/help.html
@@ -55,7 +55,7 @@
     <strong><a id="summary-with-red-bug-and-link">Example: Summary with red bug symbol</a></strong>
     <p>
         The following example adds a red bug badge symbol the text, "This is a red bug with a link", and a link:
-        <pre><code>addSummary icon: 'symbol-bug plugin-ionicons-api', text: 'This is a red bug with a link', style: 'color: red', link: 'https://issues.jenkins.io/browse/JENKINS-59646'</code></pre>
+        <pre><code>addSummary icon: 'symbol-bug plugin-ionicons-api', text: 'This is a red bug with a link', style: 'color: red', link: 'https://issues.jenkins.io/browse/JENKINS-59646', target: '_blank'</code></pre>
     </p>
 
 </div>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStep/config.jelly
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStep/config.jelly
@@ -34,4 +34,7 @@ THE SOFTWARE.
     <f:entry field="link" title="Link">
         <f:textbox/>
     </f:entry>
+    <f:entry field="target" title="Target">
+        <f:textbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStep/help-target.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStep/help-target.html
@@ -1,0 +1,3 @@
+<div>
+    Optional target frame that is used when http link is opened.
+</div>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStep/help.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStep/help.html
@@ -15,6 +15,6 @@
     <strong><a id="badge-with-text-and-link">Example: Badge with text and link</a></strong>
     <p>
         The following example adds a warning badge with the text, "This is alarming" and a link:
-        <pre><code>addWarningBadge text: 'This is alarming', link: 'https://issues.jenkins.io/browse/JENKINS-59646'</code></pre>
+        <pre><code>addWarningBadge text: 'This is alarming', link: 'https://issues.jenkins.io/browse/JENKINS-59646', target: '_blank'</code></pre>
     </p>
 </div>

--- a/src/test/java/com/jenkinsci/plugins/badge/action/AbstractBadgeActionTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/action/AbstractBadgeActionTest.java
@@ -218,8 +218,8 @@ abstract class AbstractBadgeActionTest {
         action.setTarget("");
         assertEquals("", action.getTarget());
 
-        action.setTarget("_blank");
-        assertEquals("_blank", action.getTarget());
+        action.setTarget("target");
+        assertEquals("target", action.getTarget());
     }
 
     @Test

--- a/src/test/java/com/jenkinsci/plugins/badge/action/AbstractBadgeActionTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/action/AbstractBadgeActionTest.java
@@ -54,20 +54,20 @@ abstract class AbstractBadgeActionTest {
 
     @Test
     void id() {
-        AbstractBadgeAction action = createAction(null, "icon", "text", "cssClass", "style", "link");
+        AbstractBadgeAction action = createAction(null, "icon", "text", "cssClass", "style", "link", "target");
         assertNotNull(action.getId());
         assertTrue(action.getId().matches("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"));
 
-        action = createAction("id", "icon", "text", "cssClass", "style", "link");
+        action = createAction("id", "icon", "text", "cssClass", "style", "link", "target");
         assertEquals("id", action.getId());
 
-        action = createAction("", "icon", "text", "cssClass", "style", "link");
+        action = createAction("", "icon", "text", "cssClass", "style", "link", "target");
         assertEquals("", action.getId());
     }
 
     @Test
     void icon() {
-        AbstractBadgeAction action = createAction("id", null, "text", "cssClass", "style", "link");
+        AbstractBadgeAction action = createAction("id", null, "text", "cssClass", "style", "link", "target");
         assertNull(action.getIcon());
 
         action.setIcon("");
@@ -126,7 +126,7 @@ abstract class AbstractBadgeActionTest {
 
     @Test
     void text() {
-        AbstractBadgeAction action = createAction("id", "icon", null, "cssClass", "style", "link");
+        AbstractBadgeAction action = createAction("id", "icon", null, "cssClass", "style", "link", "target");
         assertNull(action.getText());
 
         action.setText("");
@@ -163,7 +163,7 @@ abstract class AbstractBadgeActionTest {
 
     @Test
     void cssClass() {
-        AbstractBadgeAction action = createAction("id", "icon", "text", null, "style", "link");
+        AbstractBadgeAction action = createAction("id", "icon", "text", null, "style", "link", "target");
         assertNull(action.getCssClass());
 
         action.setCssClass("");
@@ -175,7 +175,7 @@ abstract class AbstractBadgeActionTest {
 
     @Test
     void style() {
-        AbstractBadgeAction action = createAction("id", "icon", "text", "cssClass", null, "link");
+        AbstractBadgeAction action = createAction("id", "icon", "text", "cssClass", null, "link", "target");
         assertNull(action.getStyle());
 
         action.setStyle("");
@@ -187,7 +187,7 @@ abstract class AbstractBadgeActionTest {
 
     @Test
     void link() {
-        AbstractBadgeAction action = createAction("id", "icon", "text", "cssClass", "style", null);
+        AbstractBadgeAction action = createAction("id", "icon", "text", "cssClass", "style", null, null);
         assertNull(action.getLink());
 
         action.setLink("");
@@ -208,24 +208,24 @@ abstract class AbstractBadgeActionTest {
 
     @Test
     void iconFileName() {
-        AbstractBadgeAction action = createAction(null, null, null, null, null, null);
+        AbstractBadgeAction action = createAction(null, null, null, null, null, null, null);
         assertEquals(getIconFileName(), action.getIconFileName());
     }
 
     @Test
     void displayName() {
-        AbstractBadgeAction action = createAction(null, null, null, null, null, null);
+        AbstractBadgeAction action = createAction(null, null, null, null, null, null, null);
         assertEquals(getDisplayName(), action.getDisplayName());
     }
 
     @Test
     void urlName() {
-        AbstractBadgeAction action = createAction(null, null, null, null, null, null);
+        AbstractBadgeAction action = createAction(null, null, null, null, null, null, null);
         assertEquals(getUrlName(), action.getUrlName());
     }
 
     protected abstract AbstractBadgeAction createAction(
-            String id, String icon, String text, String cssClass, String style, String link);
+            String id, String icon, String text, String cssClass, String style, String link, String target);
 
     protected abstract String getDisplayName();
 

--- a/src/test/java/com/jenkinsci/plugins/badge/action/AbstractBadgeActionTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/action/AbstractBadgeActionTest.java
@@ -53,6 +53,10 @@ abstract class AbstractBadgeActionTest {
     }
 
     @Test
+    @Deprecated
+    abstract void deprecatedConstructor();
+
+    @Test
     void id() {
         AbstractBadgeAction action = createAction(null, "icon", "text", "cssClass", "style", "link", "target");
         assertNotNull(action.getId());
@@ -204,6 +208,18 @@ abstract class AbstractBadgeActionTest {
 
         action.setLink("mailto:foo@bar.com");
         assertEquals("mailto:foo@bar.com", action.getLink());
+    }
+
+    @Test
+    void target() {
+        AbstractBadgeAction action = createAction("id", "icon", "text", "cssClass", "style", "link", null);
+        assertNull(action.getTarget());
+
+        action.setTarget("");
+        assertEquals("", action.getTarget());
+
+        action.setTarget("_blank");
+        assertEquals("_blank", action.getTarget());
     }
 
     @Test

--- a/src/test/java/com/jenkinsci/plugins/badge/action/BadgeActionTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/action/BadgeActionTest.java
@@ -23,7 +23,6 @@
  */
 package com.jenkinsci.plugins.badge.action;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
@@ -32,13 +31,12 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 @WithJenkins
 class BadgeActionTest extends AbstractBadgeActionTest {
 
+    @Override
     @Test
-    void target() {
-        BadgeAction action = (BadgeAction) createAction("id", "icon", "text", "cssClass", "style", "link", null);
+    @Deprecated
+    void deprecatedConstructor() {
+        BadgeAction action = new BadgeAction("id", "icon", "text", "cssClass", "style", "link");
         assertNull(action.getTarget());
-
-        action.setTarget("_blank");
-        assertEquals("_blank", action.getTarget());
     }
 
     @Override

--- a/src/test/java/com/jenkinsci/plugins/badge/action/BadgeActionTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/action/BadgeActionTest.java
@@ -23,15 +23,28 @@
  */
 package com.jenkinsci.plugins.badge.action;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 class BadgeActionTest extends AbstractBadgeActionTest {
 
+    @Test
+    void target() {
+        BadgeAction action = (BadgeAction) createAction("id", "icon", "text", "cssClass", "style", "link", null);
+        assertNull(action.getTarget());
+
+        action.setTarget("_blank");
+        assertEquals("_blank", action.getTarget());
+    }
+
     @Override
     protected AbstractBadgeAction createAction(
-            String id, String icon, String text, String cssClass, String style, String link) {
-        return new BadgeAction(id, icon, text, cssClass, style, link);
+            String id, String icon, String text, String cssClass, String style, String link, String target) {
+        return new BadgeAction(id, icon, text, cssClass, style, link, target);
     }
 
     @Override

--- a/src/test/java/com/jenkinsci/plugins/badge/action/BadgeSummaryActionTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/action/BadgeSummaryActionTest.java
@@ -24,6 +24,7 @@
 package com.jenkinsci.plugins.badge.action;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.jenkins.plugins.emoji.symbols.Emojis;
 import io.jenkins.plugins.ionicons.Ionicons;
@@ -33,6 +34,14 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 class BadgeSummaryActionTest extends AbstractBadgeActionTest {
+
+    @Override
+    @Test
+    @Deprecated
+    void deprecatedConstructor() {
+        BadgeSummaryAction action = new BadgeSummaryAction("id", "icon", "text", "cssClass", "style", "link");
+        assertNull(action.getTarget());
+    }
 
     @Override
     @Test

--- a/src/test/java/com/jenkinsci/plugins/badge/action/BadgeSummaryActionTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/action/BadgeSummaryActionTest.java
@@ -37,7 +37,7 @@ class BadgeSummaryActionTest extends AbstractBadgeActionTest {
     @Override
     @Test
     void icon() {
-        AbstractBadgeAction action = createAction("id", null, "text", "cssClass", "style", "link");
+        AbstractBadgeAction action = createAction("id", null, "text", "cssClass", "style", "link", "target");
         assertEquals(Jenkins.RESOURCE_PATH + "/images/16x16/empty.png", action.getIcon());
 
         action.setIcon("");
@@ -96,8 +96,8 @@ class BadgeSummaryActionTest extends AbstractBadgeActionTest {
 
     @Override
     protected AbstractBadgeAction createAction(
-            String id, String icon, String text, String cssClass, String style, String link) {
-        return new BadgeSummaryAction(id, icon, text, cssClass, style, link);
+            String id, String icon, String text, String cssClass, String style, String link, String target) {
+        return new BadgeSummaryAction(id, icon, text, cssClass, style, link, target);
     }
 
     @Override

--- a/src/test/java/com/jenkinsci/plugins/badge/action/BadgeSummaryActionTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/action/BadgeSummaryActionTest.java
@@ -23,12 +23,8 @@
  */
 package com.jenkinsci.plugins.badge.action;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import io.jenkins.plugins.emoji.symbols.Emojis;
-import io.jenkins.plugins.ionicons.Ionicons;
-import jenkins.model.Jenkins;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -41,66 +37,6 @@ class BadgeSummaryActionTest extends AbstractBadgeActionTest {
     void deprecatedConstructor() {
         BadgeSummaryAction action = new BadgeSummaryAction("id", "icon", "text", "cssClass", "style", "link");
         assertNull(action.getTarget());
-    }
-
-    @Override
-    @Test
-    void icon() {
-        AbstractBadgeAction action = createAction("id", null, "text", "cssClass", "style", "link", "target");
-        assertEquals(Jenkins.RESOURCE_PATH + "/images/16x16/empty.png", action.getIcon());
-
-        action.setIcon("");
-        assertEquals(Jenkins.RESOURCE_PATH + "/images/16x16/empty.png", action.getIcon());
-
-        action.setIcon("icon.png");
-        assertEquals(Jenkins.RESOURCE_PATH + "/images/16x16/icon.png", action.getIcon());
-
-        action.setIcon("/relative/url/icon.png");
-        assertEquals("/relative/url/icon.png", action.getIcon());
-
-        action.setIcon("symbol-rocket plugin-ionicons-api");
-        assertEquals("symbol-rocket plugin-ionicons-api", action.getIcon());
-
-        action.setIcon("symbol-cube");
-        assertEquals("symbol-cube", action.getIcon());
-
-        action.setIcon("icon-gear");
-        assertEquals("icon-gear", action.getIcon());
-
-        action.setIcon("https://host.domain/icon.png");
-        assertEquals("https://host.domain/icon.png", action.getIcon());
-
-        action.setIcon("completed.gif");
-        assertEquals("symbol-status-blue", action.getIcon());
-        action.setIcon("db_in.gif");
-        assertEquals(Ionicons.getIconClassName("cloud-upload-outline"), action.getIcon());
-        action.setIcon("db_out.gif");
-        assertEquals(Ionicons.getIconClassName("cloud-download-outline"), action.getIcon());
-        action.setIcon("delete.gif");
-        assertEquals("symbol-trash", action.getIcon());
-        action.setIcon("error.gif");
-        assertEquals("symbol-status-red", action.getIcon());
-        action.setIcon("folder.gif");
-        assertEquals("symbol-folder", action.getIcon());
-        action.setIcon("green.gif");
-        assertEquals(Emojis.getIconClassName("green_square"), action.getIcon());
-        action.setIcon("info.gif");
-        assertEquals("symbol-information-circle", action.getIcon());
-        action.setIcon("red.gif");
-        assertEquals(Emojis.getIconClassName("red_square"), action.getIcon());
-        action.setIcon("save.gif");
-        assertEquals(Ionicons.getIconClassName("save-outline"), action.getIcon());
-        action.setIcon("success.gif");
-        assertEquals("symbol-status-blue", action.getIcon());
-        action.setIcon("text.gif");
-        assertEquals("symbol-document-text", action.getIcon());
-        action.setIcon("warning.gif");
-        assertEquals("symbol-status-yellow", action.getIcon());
-        action.setIcon("yellow.gif");
-        assertEquals(Emojis.getIconClassName("yellow_square"), action.getIcon());
-
-        action.setIcon("blue.gif");
-        assertEquals(Jenkins.RESOURCE_PATH + "/images/16x16/blue.gif", action.getIcon());
     }
 
     @Override

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AbstractAddBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AbstractAddBadgeStepTest.java
@@ -45,19 +45,19 @@ abstract class AbstractAddBadgeStepTest {
 
     @Test
     void id() {
-        AbstractAddBadgeStep step = createStep(null, "icon", "text", "cssClass", "style", "link", "_blank");
+        AbstractAddBadgeStep step = createStep(null, "icon", "text", "cssClass", "style", "link", "target");
         assertNull(step.getId());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "target");
         assertEquals("id", step.getId());
 
-        step = createStep("", "icon", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("", "icon", "text", "cssClass", "style", "link", "target");
         assertEquals("", step.getId());
     }
 
     @Test
     void icon() {
-        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link", "target");
         assertNull(step.getIcon());
 
         step.setIcon("");
@@ -69,7 +69,7 @@ abstract class AbstractAddBadgeStepTest {
 
     @Test
     void text() {
-        AbstractAddBadgeStep step = createStep("id", "icon", null, "cssClass", "style", "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", "icon", null, "cssClass", "style", "link", "target");
         assertNull(step.getText());
 
         step.setText("");
@@ -81,7 +81,7 @@ abstract class AbstractAddBadgeStepTest {
 
     @Test
     void cssClass() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link", "target");
         assertNull(step.getCssClass());
 
         step.setCssClass("");
@@ -93,7 +93,7 @@ abstract class AbstractAddBadgeStepTest {
 
     @Test
     void style() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link", "target");
         assertNull(step.getStyle());
 
         step.setStyle("");
@@ -105,7 +105,7 @@ abstract class AbstractAddBadgeStepTest {
 
     @Test
     void link() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", "style", null, null);
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", "style", null, "target");
         assertNull(step.getLink());
 
         step.setLink("");
@@ -116,8 +116,20 @@ abstract class AbstractAddBadgeStepTest {
     }
 
     @Test
+    void target() {
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", "style", "link", null);
+        assertNull(step.getTarget());
+
+        step.setTarget("");
+        assertEquals("", step.getTarget());
+
+        step.setTarget("target");
+        assertEquals("target", step.getTarget());
+    }
+
+    @Test
     void string() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", "style", "link", "target");
         assertNotNull(step.toString());
         assertTrue(step.toString().startsWith(step.getDescriptor().getFunctionName()));
 

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AbstractAddBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AbstractAddBadgeStepTest.java
@@ -45,19 +45,19 @@ abstract class AbstractAddBadgeStepTest {
 
     @Test
     void id() {
-        AbstractAddBadgeStep step = createStep(null, "icon", "text", "cssClass", "style", "link");
+        AbstractAddBadgeStep step = createStep(null, "icon", "text", "cssClass", "style", "link", "_blank");
         assertNull(step.getId());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
         assertEquals("id", step.getId());
 
-        step = createStep("", "icon", "text", "cssClass", "style", "link");
+        step = createStep("", "icon", "text", "cssClass", "style", "link", "_blank");
         assertEquals("", step.getId());
     }
 
     @Test
     void icon() {
-        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link");
+        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link", "_blank");
         assertNull(step.getIcon());
 
         step.setIcon("");
@@ -69,7 +69,7 @@ abstract class AbstractAddBadgeStepTest {
 
     @Test
     void text() {
-        AbstractAddBadgeStep step = createStep("id", "icon", null, "cssClass", "style", "link");
+        AbstractAddBadgeStep step = createStep("id", "icon", null, "cssClass", "style", "link", "_blank");
         assertNull(step.getText());
 
         step.setText("");
@@ -81,7 +81,7 @@ abstract class AbstractAddBadgeStepTest {
 
     @Test
     void cssClass() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link", "_blank");
         assertNull(step.getCssClass());
 
         step.setCssClass("");
@@ -93,7 +93,7 @@ abstract class AbstractAddBadgeStepTest {
 
     @Test
     void style() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link", "_blank");
         assertNull(step.getStyle());
 
         step.setStyle("");
@@ -105,7 +105,7 @@ abstract class AbstractAddBadgeStepTest {
 
     @Test
     void link() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", "style", null);
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", "style", null, null);
         assertNull(step.getLink());
 
         step.setLink("");
@@ -117,15 +117,15 @@ abstract class AbstractAddBadgeStepTest {
 
     @Test
     void string() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", "style", "link");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
         assertNotNull(step.toString());
         assertTrue(step.toString().startsWith(step.getDescriptor().getFunctionName()));
 
-        step = createStep(null, null, null, null, null, null);
+        step = createStep(null, null, null, null, null, null, null);
         assertNotNull(step.toString());
         assertEquals(step.getDescriptor().getFunctionName() + "()", step.toString());
     }
 
     protected abstract AbstractAddBadgeStep createStep(
-            String id, String icon, String text, String cssClass, String style, String link);
+            String id, String icon, String text, String cssClass, String style, String link, String target);
 }

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStepTest.java
@@ -31,8 +31,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.jenkinsci.plugins.badge.action.AbstractBadgeAction;
-import com.jenkinsci.plugins.badge.action.BadgeAction;
-import hudson.model.BuildBadgeAction;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -70,7 +68,7 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
     @Test
     @Deprecated(since = "2.0", forRemoval = true)
     void color() {
-        AddBadgeStep step = (AddBadgeStep) createStep("id", "icon", "text", "cssClass", null, "link", "_blank");
+        AddBadgeStep step = (AddBadgeStep) createStep("id", "icon", "text", "cssClass", null, "link", "target");
         assertNull(step.getColor());
 
         step.setColor("");
@@ -189,6 +187,9 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
             assertEquals(
                     action.getLink(),
                     Optional.of(json.get("link")).filter(nullable).orElse(null));
+            assertEquals(
+                    action.getTarget(),
+                    Optional.of(json.get("target")).filter(nullable).orElse(null));
 
             // XML
             response = webClient
@@ -227,6 +228,11 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
             assertEquals(
                     action.getLink(),
                     Optional.ofNullable(xml.getElementsByTagName("link").item(0))
+                            .orElse(mockNode)
+                            .getTextContent());
+            assertEquals(
+                    action.getTarget(),
+                    Optional.ofNullable(xml.getElementsByTagName("target").item(0))
                             .orElse(mockNode)
                             .getTextContent());
         }
@@ -313,10 +319,10 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
     }
 
     protected void assertFields(AbstractAddBadgeStep step, WorkflowRun run) {
-        List<BuildBadgeAction> badgeActions = run.getBadgeActions();
+        List<AbstractBadgeAction> badgeActions = run.getActions(AbstractBadgeAction.class);
         assertEquals(1, badgeActions.size());
 
-        BadgeAction action = (BadgeAction) badgeActions.get(0);
+        AbstractBadgeAction action = badgeActions.get(0);
         assertEquals(step.getId(), action.getId());
         assertEquals(step.getIcon(), action.getIcon());
         assertEquals(step.getText(), action.getText());

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddBadgeStepTest.java
@@ -57,19 +57,20 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
     @Override
     @Test
     void defaultConstructor() {
-        AbstractAddBadgeStep step = new AddBadgeStep();
+        AddBadgeStep step = new AddBadgeStep();
         assertNull(step.getId());
         assertNull(step.getIcon());
         assertNull(step.getText());
         assertNull(step.getCssClass());
         assertNull(step.getStyle());
         assertNull(step.getLink());
+        assertNull(step.getTarget());
     }
 
     @Test
     @Deprecated(since = "2.0", forRemoval = true)
     void color() {
-        AddBadgeStep step = (AddBadgeStep) createStep("id", "icon", "text", "cssClass", null, "link");
+        AddBadgeStep step = (AddBadgeStep) createStep("id", "icon", "text", "cssClass", null, "link", "_blank");
         assertNull(step.getColor());
 
         step.setColor("");
@@ -87,7 +88,8 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
                 "Test Text",
                 "icon-md",
                 "color: green",
-                "https://jenkins.io");
+                "https://jenkins.io",
+                "_blank");
         runAddJob(step, false, false);
     }
 
@@ -99,13 +101,14 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
                 "Test Text",
                 "icon-md",
                 "color: green",
-                "https://jenkins.io");
+                "https://jenkins.io",
+                "_blank");
         runAddJob(step, true, false);
     }
 
     @Test
     void addInDeclarativePipeline() throws Exception {
-        AbstractAddBadgeStep step = createStep(UUID.randomUUID().toString(), null, null, null, null, null);
+        AbstractAddBadgeStep step = createStep(UUID.randomUUID().toString(), null, null, null, null, null, null);
         runAddJob(step, false, true);
     }
 
@@ -117,7 +120,8 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
                 "Test Text",
                 "icon-md",
                 "color: green",
-                "https://jenkins.io");
+                "https://jenkins.io",
+                "_blank");
         runModifyJob(step, false, false);
     }
 
@@ -129,13 +133,14 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
                 "Test Text",
                 "icon-md",
                 "color: green",
-                "https://jenkins.io");
+                "https://jenkins.io",
+                "_blank");
         runModifyJob(step, true, false);
     }
 
     @Test
     void modifyInDeclarativePipeline() throws Exception {
-        AbstractAddBadgeStep step = createStep(UUID.randomUUID().toString(), null, "Test Text", null, null, null);
+        AbstractAddBadgeStep step = createStep(UUID.randomUUID().toString(), null, "Test Text", null, null, null, null);
         runModifyJob(step, false, true);
     }
 
@@ -147,7 +152,8 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
                 "Test Text",
                 "icon-md",
                 "color: green",
-                "https://jenkins.io");
+                "https://jenkins.io",
+                "_blank");
         WorkflowRun job = runAddJob(step, false, false);
 
         WorkflowRun bean = assertInstanceOf(WorkflowRun.class, job.getApi().bean);
@@ -239,17 +245,17 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
         if (declarativePipeline) {
             script =
                     """
-        pipeline {
-            agent any
-            stages {
-                stage('Testing') {
-                    steps {
-                        %s
-                    }
-                }
-            }
-        }
-        """
+              pipeline {
+                  agent any
+                  stages {
+                      stage('Testing') {
+                          steps {
+                              %s
+                          }
+                      }
+                  }
+              }
+              """
                             .formatted(script);
         }
 
@@ -281,19 +287,19 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
         if (declarativePipeline) {
             script =
                     """
-            pipeline {
-                agent any
-                stages {
-                    stage('Testing') {
-                        steps {
-                            script {
-                                %s
-                            }
-                        }
-                    }
-                }
-            }
-            """
+              pipeline {
+                  agent any
+                  stages {
+                      stage('Testing') {
+                          steps {
+                              script {
+                                  %s
+                              }
+                          }
+                      }
+                  }
+              }
+              """
                             .formatted(script);
         }
 
@@ -317,11 +323,12 @@ class AddBadgeStepTest extends AbstractAddBadgeStepTest {
         assertEquals(step.getCssClass(), action.getCssClass());
         assertEquals(step.getStyle(), action.getStyle());
         assertEquals(step.getLink(), action.getLink());
+        assertEquals(step.getTarget(), action.getTarget());
     }
 
     @Override
     protected AbstractAddBadgeStep createStep(
-            String id, String icon, String text, String cssClass, String style, String link) {
-        return new AddBadgeStep(id, icon, text, cssClass, style, link);
+            String id, String icon, String text, String cssClass, String style, String link, String target) {
+        return new AddBadgeStep(id, icon, text, cssClass, style, link, target);
     }
 }

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStepTest.java
@@ -47,45 +47,45 @@ class AddErrorBadgeStepTest extends AddBadgeStepTest {
     @Override
     @Test
     void icon() {
-        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link");
+        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link", "_blank");
         assertEquals("symbol-remove-circle plugin-ionicons-api", step.getIcon());
 
-        step = createStep("id", "", "text", "cssClass", "style", "link");
+        step = createStep("id", "", "text", "cssClass", "style", "link", "_blank");
         assertEquals("symbol-remove-circle plugin-ionicons-api", step.getIcon());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
         assertEquals("symbol-remove-circle plugin-ionicons-api", step.getIcon());
     }
 
     @Override
     @Test
     void cssClass() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link", "_blank");
         assertNull(step.getCssClass());
 
-        step = createStep("id", "icon", "text", "", "style", "link");
+        step = createStep("id", "icon", "text", "", "style", "link", "_blank");
         assertNull(step.getCssClass());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
         assertNull(step.getCssClass());
     }
 
     @Override
     @Test
     void style() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link", "_blank");
         assertEquals("color: var(--error-color)", step.getStyle());
 
-        step = createStep("id", "icon", "text", "cssClass", "", "link");
+        step = createStep("id", "icon", "text", "cssClass", "", "link", "_blank");
         assertEquals("color: var(--error-color)", step.getStyle());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
         assertEquals("color: var(--error-color)", step.getStyle());
     }
 
     @Override
     protected AbstractAddBadgeStep createStep(
-            String id, String icon, String text, String cssClass, String style, String link) {
-        return new AddErrorBadgeStep(id, text, link);
+            String id, String icon, String text, String cssClass, String style, String link, String target) {
+        return new AddErrorBadgeStep(id, text, link, target);
     }
 }

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddErrorBadgeStepTest.java
@@ -42,44 +42,45 @@ class AddErrorBadgeStepTest extends AddBadgeStepTest {
         assertNull(step.getCssClass());
         assertEquals("color: var(--error-color)", step.getStyle());
         assertNull(step.getLink());
+        assertNull(step.getTarget());
     }
 
     @Override
     @Test
     void icon() {
-        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link", "target");
         assertEquals("symbol-remove-circle plugin-ionicons-api", step.getIcon());
 
-        step = createStep("id", "", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("id", "", "text", "cssClass", "style", "link", "target");
         assertEquals("symbol-remove-circle plugin-ionicons-api", step.getIcon());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "target");
         assertEquals("symbol-remove-circle plugin-ionicons-api", step.getIcon());
     }
 
     @Override
     @Test
     void cssClass() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link", "target");
         assertNull(step.getCssClass());
 
-        step = createStep("id", "icon", "text", "", "style", "link", "_blank");
+        step = createStep("id", "icon", "text", "", "style", "link", "target");
         assertNull(step.getCssClass());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "target");
         assertNull(step.getCssClass());
     }
 
     @Override
     @Test
     void style() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link", "target");
         assertEquals("color: var(--error-color)", step.getStyle());
 
-        step = createStep("id", "icon", "text", "cssClass", "", "link", "_blank");
+        step = createStep("id", "icon", "text", "cssClass", "", "link", "target");
         assertEquals("color: var(--error-color)", step.getStyle());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "target");
         assertEquals("color: var(--error-color)", step.getStyle());
     }
 

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStepTest.java
@@ -47,45 +47,45 @@ class AddInfoBadgeStepTest extends AddBadgeStepTest {
     @Override
     @Test
     void icon() {
-        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link");
+        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link", "_blank");
         assertEquals("symbol-information-circle plugin-ionicons-api", step.getIcon());
 
-        step = createStep("id", "", "text", "cssClass", "style", "link");
+        step = createStep("id", "", "text", "cssClass", "style", "link", "_blank");
         assertEquals("symbol-information-circle plugin-ionicons-api", step.getIcon());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
         assertEquals("symbol-information-circle plugin-ionicons-api", step.getIcon());
     }
 
     @Override
     @Test
     void cssClass() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link", "_blank");
         assertNull(step.getCssClass());
 
-        step = createStep("id", "icon", "text", "", "style", "link");
+        step = createStep("id", "icon", "text", "", "style", "link", "_blank");
         assertNull(step.getCssClass());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
         assertNull(step.getCssClass());
     }
 
     @Override
     @Test
     void style() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link", "_blank");
         assertEquals("color: var(--blue)", step.getStyle());
 
-        step = createStep("id", "icon", "text", "cssClass", "", "link");
+        step = createStep("id", "icon", "text", "cssClass", "", "link", "_blank");
         assertEquals("color: var(--blue)", step.getStyle());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
         assertEquals("color: var(--blue)", step.getStyle());
     }
 
     @Override
     protected AbstractAddBadgeStep createStep(
-            String id, String icon, String text, String cssClass, String style, String link) {
-        return new AddInfoBadgeStep(id, text, link);
+            String id, String icon, String text, String cssClass, String style, String link, String target) {
+        return new AddInfoBadgeStep(id, text, link, target);
     }
 }

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddInfoBadgeStepTest.java
@@ -42,44 +42,45 @@ class AddInfoBadgeStepTest extends AddBadgeStepTest {
         assertNull(step.getCssClass());
         assertEquals("color: var(--blue)", step.getStyle());
         assertNull(step.getLink());
+        assertNull(step.getTarget());
     }
 
     @Override
     @Test
     void icon() {
-        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link", "target");
         assertEquals("symbol-information-circle plugin-ionicons-api", step.getIcon());
 
-        step = createStep("id", "", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("id", "", "text", "cssClass", "style", "link", "target");
         assertEquals("symbol-information-circle plugin-ionicons-api", step.getIcon());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "target");
         assertEquals("symbol-information-circle plugin-ionicons-api", step.getIcon());
     }
 
     @Override
     @Test
     void cssClass() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link", "target");
         assertNull(step.getCssClass());
 
-        step = createStep("id", "icon", "text", "", "style", "link", "_blank");
+        step = createStep("id", "icon", "text", "", "style", "link", "target");
         assertNull(step.getCssClass());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "target");
         assertNull(step.getCssClass());
     }
 
     @Override
     @Test
     void style() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link", "target");
         assertEquals("color: var(--blue)", step.getStyle());
 
-        step = createStep("id", "icon", "text", "cssClass", "", "link", "_blank");
+        step = createStep("id", "icon", "text", "cssClass", "", "link", "target");
         assertEquals("color: var(--blue)", step.getStyle());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "target");
         assertEquals("color: var(--blue)", step.getStyle());
     }
 

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddSummaryStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddSummaryStepTest.java
@@ -23,14 +23,8 @@
  */
 package com.jenkinsci.plugins.badge.dsl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import com.jenkinsci.plugins.badge.action.BadgeSummaryAction;
-import java.util.List;
-import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -47,29 +41,12 @@ class AddSummaryStepTest extends AddBadgeStepTest {
         assertNull(step.getCssClass());
         assertNull(step.getStyle());
         assertNull(step.getLink());
-    }
-
-    @Override
-    protected void assertFields(AbstractAddBadgeStep step, WorkflowRun run) {
-        List<BadgeSummaryAction> summaryActions = run.getActions(BadgeSummaryAction.class);
-        assertEquals(1, summaryActions.size());
-
-        BadgeSummaryAction action = summaryActions.get(0);
-        assertEquals(step.getId(), action.getId());
-        if (StringUtils.isEmpty(step.getIcon())) {
-            assertEquals(Jenkins.RESOURCE_PATH + "/images/16x16/empty.png", action.getIcon());
-        } else {
-            assertEquals(step.getIcon(), action.getIcon());
-        }
-        assertEquals(step.getText(), action.getText());
-        assertEquals(step.getCssClass(), action.getCssClass());
-        assertEquals(step.getStyle(), action.getStyle());
-        assertEquals(step.getLink(), action.getLink());
+        assertNull(step.getTarget());
     }
 
     @Override
     protected AbstractAddBadgeStep createStep(
             String id, String icon, String text, String cssClass, String style, String link, String target) {
-        return new AddSummaryStep(id, icon, text, cssClass, style, link);
+        return new AddSummaryStep(id, icon, text, cssClass, style, link, target);
     }
 }

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddSummaryStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddSummaryStepTest.java
@@ -69,7 +69,7 @@ class AddSummaryStepTest extends AddBadgeStepTest {
 
     @Override
     protected AbstractAddBadgeStep createStep(
-            String id, String icon, String text, String cssClass, String style, String link) {
+            String id, String icon, String text, String cssClass, String style, String link, String target) {
         return new AddSummaryStep(id, icon, text, cssClass, style, link);
     }
 }

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStepTest.java
@@ -42,44 +42,45 @@ class AddWarningBadgeStepTest extends AddBadgeStepTest {
         assertNull(step.getCssClass());
         assertEquals("color: var(--warning-color)", step.getStyle());
         assertNull(step.getLink());
+        assertNull(step.getTarget());
     }
 
     @Override
     @Test
     void icon() {
-        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link", "target");
         assertEquals("symbol-warning plugin-ionicons-api", step.getIcon());
 
-        step = createStep("id", "", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("id", "", "text", "cssClass", "style", "link", "target");
         assertEquals("symbol-warning plugin-ionicons-api", step.getIcon());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "target");
         assertEquals("symbol-warning plugin-ionicons-api", step.getIcon());
     }
 
     @Override
     @Test
     void cssClass() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link", "target");
         assertNull(step.getCssClass());
 
-        step = createStep("id", "icon", "text", "", "style", "link", "_blank");
+        step = createStep("id", "icon", "text", "", "style", "link", "target");
         assertNull(step.getCssClass());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "target");
         assertNull(step.getCssClass());
     }
 
     @Override
     @Test
     void style() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link", "_blank");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link", "target");
         assertEquals("color: var(--warning-color)", step.getStyle());
 
-        step = createStep("id", "icon", "text", "cssClass", "", "link", "_blank");
+        step = createStep("id", "icon", "text", "cssClass", "", "link", "target");
         assertEquals("color: var(--warning-color)", step.getStyle());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "target");
         assertEquals("color: var(--warning-color)", step.getStyle());
     }
 

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/AddWarningBadgeStepTest.java
@@ -47,45 +47,45 @@ class AddWarningBadgeStepTest extends AddBadgeStepTest {
     @Override
     @Test
     void icon() {
-        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link");
+        AbstractAddBadgeStep step = createStep("id", null, "text", "cssClass", "style", "link", "_blank");
         assertEquals("symbol-warning plugin-ionicons-api", step.getIcon());
 
-        step = createStep("id", "", "text", "cssClass", "style", "link");
+        step = createStep("id", "", "text", "cssClass", "style", "link", "_blank");
         assertEquals("symbol-warning plugin-ionicons-api", step.getIcon());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
         assertEquals("symbol-warning plugin-ionicons-api", step.getIcon());
     }
 
     @Override
     @Test
     void cssClass() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", null, "style", "link", "_blank");
         assertNull(step.getCssClass());
 
-        step = createStep("id", "icon", "text", "", "style", "link");
+        step = createStep("id", "icon", "text", "", "style", "link", "_blank");
         assertNull(step.getCssClass());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
         assertNull(step.getCssClass());
     }
 
     @Override
     @Test
     void style() {
-        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link");
+        AbstractAddBadgeStep step = createStep("id", "icon", "text", "cssClass", null, "link", "_blank");
         assertEquals("color: var(--warning-color)", step.getStyle());
 
-        step = createStep("id", "icon", "text", "cssClass", "", "link");
+        step = createStep("id", "icon", "text", "cssClass", "", "link", "_blank");
         assertEquals("color: var(--warning-color)", step.getStyle());
 
-        step = createStep("id", "icon", "text", "cssClass", "style", "link");
+        step = createStep("id", "icon", "text", "cssClass", "style", "link", "_blank");
         assertEquals("color: var(--warning-color)", step.getStyle());
     }
 
     @Override
     protected AbstractAddBadgeStep createStep(
-            String id, String icon, String text, String cssClass, String style, String link) {
-        return new AddWarningBadgeStep(id, text, link);
+            String id, String icon, String text, String cssClass, String style, String link, String target) {
+        return new AddWarningBadgeStep(id, text, link, target);
     }
 }

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/RemoveBadgesStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/RemoveBadgesStepTest.java
@@ -26,7 +26,7 @@ package com.jenkinsci.plugins.badge.dsl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import hudson.model.BuildBadgeAction;
+import com.jenkinsci.plugins.badge.action.AbstractBadgeAction;
 import java.util.List;
 import java.util.UUID;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -158,7 +158,7 @@ class RemoveBadgesStepTest extends AbstractRemoveBadgesStepTest {
     }
 
     protected void assertActionExists(WorkflowRun run, int expected) {
-        List<BuildBadgeAction> badgeActions = run.getBadgeActions();
+        List<AbstractBadgeAction> badgeActions = run.getActions(AbstractBadgeAction.class);
         assertEquals(expected, badgeActions.size());
     }
 

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/RemoveBadgesStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/RemoveBadgesStepTest.java
@@ -164,7 +164,13 @@ class RemoveBadgesStepTest extends AbstractRemoveBadgesStepTest {
 
     protected AbstractAddBadgeStep createAddStep(String id) {
         return new AddBadgeStep(
-                id, "symbol-rocket plugin-ionicons-api", "Test Text", "icon-md", "color: green", "https://jenkins.io");
+                id,
+                "symbol-rocket plugin-ionicons-api",
+                "Test Text",
+                "icon-md",
+                "color: green",
+                "https://jenkins.io",
+                "_blank");
     }
 
     @Override

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/RemoveSummariesStepTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/RemoveSummariesStepTest.java
@@ -23,12 +23,8 @@
  */
 package com.jenkinsci.plugins.badge.dsl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import com.jenkinsci.plugins.badge.action.BadgeSummaryAction;
-import java.util.List;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -43,15 +39,15 @@ class RemoveSummariesStepTest extends RemoveBadgesStepTest {
     }
 
     @Override
-    protected void assertActionExists(WorkflowRun run, int expected) {
-        List<BadgeSummaryAction> summaryActions = run.getActions(BadgeSummaryAction.class);
-        assertEquals(expected, summaryActions.size());
-    }
-
-    @Override
     protected AbstractAddBadgeStep createAddStep(String id) {
         return new AddSummaryStep(
-                id, "symbol-rocket plugin-ionicons-api", "Test Text", "icon-md", "color: green", "https://jenkins.io");
+                id,
+                "symbol-rocket plugin-ionicons-api",
+                "Test Text",
+                "icon-md",
+                "color: green",
+                "https://jenkins.io",
+                "_blank");
     }
 
     @Override

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/UITest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/UITest.java
@@ -55,6 +55,7 @@ class UITest {
                 assertEquals("icon-sm", icon.getAttribute("class"));
                 assertEquals(step.getStyle(), badge.getAttribute("style"));
                 assertEquals(step.getLink(), badge.getAttribute("href"));
+                assertEquals(step.getTarget(), badge.getAttribute("target"));
             }
         }
 
@@ -212,7 +213,8 @@ class UITest {
                     "Test Text",
                     "Test Class",
                     "Test Style",
-                    "https://jenkins.io");
+                    "https://jenkins.io",
+                    "_blank");
             WorkflowJob job = runJob(step, null);
 
             try (JenkinsRule.WebClient webClient = r.createWebClient()) {
@@ -230,16 +232,17 @@ class UITest {
                 assertEquals("span", text.getTagName());
 
                 assertEquals(step.getText(), text.getTextContent());
-                assertEquals(step.getCssClass(), text.getAttribute("class"));
-                assertEquals(step.getStyle(), text.getAttribute("style"));
+                assertEquals(step.getCssClass(), link.getAttribute("class"));
+                assertEquals(step.getStyle(), link.getAttribute("style"));
                 assertEquals(step.getLink(), link.getAttribute("href"));
+                assertEquals(step.getTarget(), link.getAttribute("target"));
             }
         }
 
         @Test
         void iconWithTextWithoutLink() throws Throwable {
             AddSummaryStep step = new AddSummaryStep(
-                    null, "symbol-rocket plugin-ionicons-api", "Test Text", "Test Class", "Test Style", null);
+                    null, "symbol-rocket plugin-ionicons-api", "Test Text", "Test Class", "Test Style", null, null);
             WorkflowJob job = runJob(step, null);
 
             try (JenkinsRule.WebClient webClient = r.createWebClient()) {
@@ -263,7 +266,7 @@ class UITest {
         @Test
         void iconWithoutTextWithoutLink() throws Throwable {
             AddSummaryStep step = new AddSummaryStep(
-                    null, "symbol-rocket plugin-ionicons-api", null, "Test Class", "Test Style", null);
+                    null, "symbol-rocket plugin-ionicons-api", null, "Test Class", "Test Style", null, null);
             WorkflowJob job = runJob(step, null);
 
             try (JenkinsRule.WebClient webClient = r.createWebClient()) {
@@ -286,8 +289,8 @@ class UITest {
 
         @Test
         void textWithoutIconWithLink() throws Throwable {
-            AddSummaryStep step =
-                    new AddSummaryStep(null, null, "Test Text", "Test Class", "Test Style", "https://jenkins.io");
+            AddSummaryStep step = new AddSummaryStep(
+                    null, null, "Test Text", "Test Class", "Test Style", "https://jenkins.io", "_blank");
             WorkflowJob job = runJob(step, null);
 
             try (JenkinsRule.WebClient webClient = r.createWebClient()) {
@@ -306,15 +309,16 @@ class UITest {
 
                 assertEquals("/jenkins" + Jenkins.RESOURCE_PATH + "/images/16x16/empty.png", icon.getAttribute("src"));
                 assertEquals(step.getText(), text.getTextContent());
-                assertEquals(step.getCssClass(), text.getAttribute("class"));
-                assertEquals(step.getStyle(), text.getAttribute("style"));
+                assertEquals(step.getCssClass(), link.getAttribute("class"));
+                assertEquals(step.getStyle(), link.getAttribute("style"));
                 assertEquals(step.getLink(), link.getAttribute("href"));
+                assertEquals(step.getTarget(), link.getAttribute("target"));
             }
         }
 
         @Test
         void textWithoutIconWithoutLink() throws Throwable {
-            AddSummaryStep step = new AddSummaryStep(null, null, "Test Text", "Test Class", "Test Style", null);
+            AddSummaryStep step = new AddSummaryStep(null, null, "Test Text", "Test Class", "Test Style", null, null);
             WorkflowJob job = runJob(step, null);
 
             try (JenkinsRule.WebClient webClient = r.createWebClient()) {
@@ -344,7 +348,8 @@ class UITest {
                     "Test Text",
                     "Test Class",
                     "Test Style",
-                    "https://jenkins.io");
+                    "https://jenkins.io",
+                    "_blank");
             RemoveSummariesStep removeStep = new RemoveSummariesStep(addStep.getId());
             WorkflowJob job = runJob(addStep, removeStep);
 

--- a/src/test/java/com/jenkinsci/plugins/badge/dsl/UITest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/dsl/UITest.java
@@ -37,16 +37,14 @@ class UITest {
                     "Test Text",
                     "Test Class",
                     "Test Style",
-                    "https://jenkins.io");
+                    "https://jenkins.io",
+                    "_blank");
             WorkflowJob job = runJob(step, null);
 
             try (JenkinsRule.WebClient webClient = r.createWebClient()) {
                 HtmlPage overview = webClient.getPage(job);
-                DomElement builds = overview.getElementById("jenkins-builds");
-
-                assertEquals(6, builds.getElementsByTagName("span").size());
-
-                DomElement badge = builds.getElementsByTagName("a").get(3);
+                DomElement badge =
+                        overview.querySelector("#jenkins-builds .app-builds-container__item__inner__controls a");
                 DomElement icon = badge.getLastElementChild();
 
                 assertEquals("a", badge.getTagName());
@@ -63,16 +61,13 @@ class UITest {
         @Test
         void iconWithoutLink() throws Throwable {
             AddBadgeStep step = new AddBadgeStep(
-                    null, "symbol-rocket plugin-ionicons-api", "Test Text", "Test Class", "Test Style", null);
+                    null, "symbol-rocket plugin-ionicons-api", "Test Text", "Test Class", "Test Style", null, null);
             WorkflowJob job = runJob(step, null);
 
             try (JenkinsRule.WebClient webClient = r.createWebClient()) {
                 HtmlPage overview = webClient.getPage(job);
-                DomElement builds = overview.getElementById("jenkins-builds");
-
-                assertEquals(6, builds.getElementsByTagName("span").size());
-
-                DomElement badge = builds.getElementsByTagName("span").get(2);
+                DomElement badge =
+                        overview.querySelector("#jenkins-builds .app-builds-container__item__inner__controls span");
                 DomElement icon = badge.getLastElementChild();
 
                 assertEquals("svg", icon.getTagName());
@@ -87,17 +82,14 @@ class UITest {
 
         @Test
         void textWithLink() throws Throwable {
-            AddBadgeStep step =
-                    new AddBadgeStep(null, null, "Test Text", "Test Class", "Test Style", "https://jenkins.io");
+            AddBadgeStep step = new AddBadgeStep(
+                    null, null, "Test Text", "Test Class", "Test Style", "https://jenkins.io", "_blank");
             WorkflowJob job = runJob(step, null);
 
             try (JenkinsRule.WebClient webClient = r.createWebClient()) {
                 HtmlPage overview = webClient.getPage(job);
-                DomElement builds = overview.getElementById("jenkins-builds");
-
-                assertEquals(5, builds.getElementsByTagName("span").size());
-
-                DomElement badge = builds.getElementsByTagName("a").get(3);
+                DomElement badge =
+                        overview.querySelector("#jenkins-builds .app-builds-container__item__inner__controls a");
 
                 assertEquals("a", badge.getTagName());
 
@@ -105,21 +97,19 @@ class UITest {
                 assertEquals(step.getCssClass(), badge.getAttribute("class"));
                 assertEquals(step.getStyle(), badge.getAttribute("style"));
                 assertEquals(step.getLink(), badge.getAttribute("href"));
+                assertEquals(step.getTarget(), badge.getAttribute("target"));
             }
         }
 
         @Test
         void textWithoutLink() throws Throwable {
-            AddBadgeStep step = new AddBadgeStep(null, null, "Test Text", "Test Class", "Test Style", null);
+            AddBadgeStep step = new AddBadgeStep(null, null, "Test Text", "Test Class", "Test Style", null, null);
             WorkflowJob job = runJob(step, null);
 
             try (JenkinsRule.WebClient webClient = r.createWebClient()) {
                 HtmlPage overview = webClient.getPage(job);
-                DomElement builds = overview.getElementById("jenkins-builds");
-
-                assertEquals(5, builds.getElementsByTagName("span").size());
-
-                DomElement badge = builds.getElementsByTagName("span").get(2);
+                DomElement badge =
+                        overview.querySelector("#jenkins-builds .app-builds-container__item__inner__controls span");
 
                 assertEquals("span", badge.getTagName());
 
@@ -131,16 +121,13 @@ class UITest {
 
         @Test
         void info() throws Throwable {
-            AddInfoBadgeStep step = new AddInfoBadgeStep(null, "Test Text", null);
+            AddInfoBadgeStep step = new AddInfoBadgeStep(null, "Test Text", null, null);
             WorkflowJob job = runJob(step, null);
 
             try (JenkinsRule.WebClient webClient = r.createWebClient()) {
                 HtmlPage overview = webClient.getPage(job);
-                DomElement builds = overview.getElementById("jenkins-builds");
-
-                assertEquals(6, builds.getElementsByTagName("span").size());
-
-                DomElement badge = builds.getElementsByTagName("span").get(2);
+                DomElement badge =
+                        overview.querySelector("#jenkins-builds .app-builds-container__item__inner__controls span");
                 DomElement icon = badge.getLastElementChild();
 
                 assertEquals("svg", icon.getTagName());
@@ -154,16 +141,13 @@ class UITest {
 
         @Test
         void warning() throws Throwable {
-            AddWarningBadgeStep step = new AddWarningBadgeStep(null, "Test Text", null);
+            AddWarningBadgeStep step = new AddWarningBadgeStep(null, "Test Text", null, null);
             WorkflowJob job = runJob(step, null);
 
             try (JenkinsRule.WebClient webClient = r.createWebClient()) {
                 HtmlPage overview = webClient.getPage(job);
-                DomElement builds = overview.getElementById("jenkins-builds");
-
-                assertEquals(6, builds.getElementsByTagName("span").size());
-
-                DomElement badge = builds.getElementsByTagName("span").get(2);
+                DomElement badge =
+                        overview.querySelector("#jenkins-builds .app-builds-container__item__inner__controls span");
                 DomElement icon = badge.getLastElementChild();
 
                 assertEquals("svg", icon.getTagName());
@@ -177,16 +161,13 @@ class UITest {
 
         @Test
         void error() throws Throwable {
-            AddErrorBadgeStep step = new AddErrorBadgeStep(null, "Test Text", null);
+            AddErrorBadgeStep step = new AddErrorBadgeStep(null, "Test Text", null, null);
             WorkflowJob job = runJob(step, null);
 
             try (JenkinsRule.WebClient webClient = r.createWebClient()) {
                 HtmlPage overview = webClient.getPage(job);
-                DomElement builds = overview.getElementById("jenkins-builds");
-
-                assertEquals(6, builds.getElementsByTagName("span").size());
-
-                DomElement badge = builds.getElementsByTagName("span").get(2);
+                DomElement badge =
+                        overview.querySelector("#jenkins-builds .app-builds-container__item__inner__controls span");
                 DomElement icon = badge.getLastElementChild();
 
                 assertEquals("svg", icon.getTagName());
@@ -206,15 +187,16 @@ class UITest {
                     "Test Text",
                     "Test Class",
                     "Test Style",
-                    "https://jenkins.io");
+                    "https://jenkins.io",
+                    "_blank");
             RemoveBadgesStep removeStep = new RemoveBadgesStep(addStep.getId());
             WorkflowJob job = runJob(addStep, removeStep);
 
             try (JenkinsRule.WebClient webClient = r.createWebClient()) {
                 HtmlPage overview = webClient.getPage(job);
-                DomElement builds = overview.getElementById("jenkins-builds");
-
-                assertEquals(4, builds.getElementsByTagName("span").size());
+                DomElement badge =
+                        overview.querySelector("#jenkins-builds .app-builds-container__item__inner__controls");
+                assertEquals(0, badge.getElementsByTagName("span").size());
             }
         }
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Add target attribute to AddBadge. Target is the anchor target, allowing badge to link to specified frame; end user does not need to context click to open link in new tab.

### Testing done
Unit tests and hpi:run manual testing to verify link with target works as expected

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
