### PR TITLE
Show test failure on Jenkins 2.504

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,6 @@ buildPlugin(
   forkCount: '1C', // Run parallel tests on ci.jenkins.io for lower costs, faster feedback
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 21, jenkins: '2.504'], // UITest fails on 2.504 and 2.505
-    [platform: 'windows', jdk: 17],
+    [platform: 'linux', jdk: 21, jenkins: '2.505'], // UITest fails on 2.504 and 2.505
+    [platform: 'windows', jdk: 17, jenkins: '2.504'],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,6 @@ buildPlugin(
   forkCount: '1C', // Run parallel tests on ci.jenkins.io for lower costs, faster feedback
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 21],
+    [platform: 'linux', jdk: 21, jenkins: '2.504'], // UITest fails on 2.504 and 2.505
     [platform: 'windows', jdk: 17],
 ])


### PR DESCRIPTION
## Show test failure on Jenkins 2.504

Jenkins 2.504 is the next LTS baseline.  Tests need to pass on the LTS baseline and on the most recent weekly Jenkins release.

### Testing done

Confirmed that UITest fails when run with the command lines:

```
mvn clean -Dtest=UITest -Djenkins.version=2.504 test
mvn clean -Dtest=UITest -Djenkins.version=2.505 test
```

Thanks to @gbhat618 for detecting the issue in plugin BOM.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
