### PR TITLE
[Docs] Restore example of how to use font-awesome (refixes #184)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -41,13 +41,13 @@ image::images/badge.png[Badge,height="250",align="center"]
 
 ==== addBadge
 
-This is the central pipeline step that allows users to add custom badges to their builds.
-A badge can either be an icon or text that can optionally be formatted as HTML rather than plain text.
-Users can also add links to the badges as well as styling to get the desired visual results.
+This is the central pipeline step that allows users to add custom badges to their builds. A badge can either be an icon
+or text that can optionally be formatted as HTML rather than plain text. Users can also add links to the badges as well
+as styling to get the desired visual results.
 
 ===== Examples
 
-See https://www.jenkins.io/doc/pipeline/steps/badge/#addbadge-add-badge[Jenkins Pipeline Steps Reference] for detailed descriptions of the supported parameters.
+See https://www.jenkins.io/doc/pipeline/steps/badge/#addbadge-add-badge[Jenkins Pipeline Steps Reference] for detailed descriptions of the supported parameters, supported icon plugins, and styling options.
 
 [source,groovy]
 ----

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help-icon.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help-icon.html
@@ -8,6 +8,7 @@
             <li><code>addBadge icon: 'symbol-alert-circle-outline plugin-ionicons-api', text: 'This is an alert symbol'</code></li>
             <li><code>addBadge icon: 'symbol-bar-chart-filled plugin-ionicons-api', text: 'This is a bar chart symbol'</code></li>
             <li><code>addBadge icon: 'symbol-emoji_sloth plugin-emoji-symbols-api', text: 'This is a sloth symbol'</code></li>
+            <li><code>addBadge icon: 'symbol-solid/flag-checkered plugin-font-awesome-api', text: 'This is a checkered flag from font-awesome. Note the slash between the icon family and the name.</code></li>
             <li><code>addBadge icon: 'symbol-cube', text: 'This is a Jenkins Core symbol'</code></li>
             <li><code>addBadge icon: 'icon-gear', text: 'This is a Jenkins Core icon'</code></li>
         </ul>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddBadgeStep/help.html
@@ -15,6 +15,8 @@
         <li><code>addBadge icon: 'symbol-alert-circle-outline plugin-ionicons-api', text: 'This is an alert symbol'</code></li>
         <li><code>addBadge icon: 'symbol-bar-chart-filled plugin-ionicons-api', text: 'This is a bar chart symbol'</code></li>
         <li><code>addBadge icon: 'symbol-battery-half-sharp plugin-ionicons-api', text: 'This is a half filled battery symbol'</code></li>
+        <li><code>addBadge icon: 'symbol-emoji_sloth plugin-emoji-symbols-api', text: 'This is a sloth symbol'</code></li>
+        <li><code>addBadge icon: 'symbol-solid/flag-checkered plugin-font-awesome-api', text: 'This is a checkered flag from font-awesome. Note the slash between the icon family and the name.</code></li>
         <li><code>addBadge icon: 'symbol-cube', text: 'This is a Jenkins Core symbol'</code></li>
         <li><code>addBadge icon: 'icon-gear', text: 'This is a Jenkins Core icon'</code></li>
     </ul>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddSummaryStep/help-icon.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddSummaryStep/help-icon.html
@@ -8,6 +8,7 @@
             <li><code>addSummary icon: 'symbol-alert-circle-outline plugin-ionicons-api', text: 'This is an alert symbol'</code></li>
             <li><code>addSummary icon: 'symbol-bar-chart-filled plugin-ionicons-api', text: 'This is a bar chart symbol'</code></li>
             <li><code>addSummary icon: 'symbol-emoji_sloth plugin-emoji-symbols-api', text: 'This is a sloth symbol'</code></li>
+            <li><code>addSummary icon: 'symbol-solid/flag-checkered plugin-font-awesome-api', text: 'This is a checkered flag from font-awesome. Note the slash between the icon family and the name.</code></li>
             <li><code>addSummary icon: 'symbol-cube', text: 'This is a Jenkins Core symbol'</code></li>
             <li><code>addSummary icon: 'icon-gear', text: 'This is a Jenkins Core icon'</code></li>
         </ul>

--- a/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddSummaryStep/help.html
+++ b/src/main/resources/com/jenkinsci/plugins/badge/dsl/AddSummaryStep/help.html
@@ -15,6 +15,8 @@
         <li><code>addSummary icon: 'symbol-alert-circle-outline plugin-ionicons-api', text: 'This is an alert symbol'</code></li>
         <li><code>addSummary icon: 'symbol-bar-chart-filled plugin-ionicons-api', text: 'This is a bar chart symbol'</code></li>
         <li><code>addSummary icon: 'symbol-battery-half-sharp plugin-ionicons-api', text: 'This is a half filled battery symbol'</code></li>
+        <li><code>addSummary icon: 'symbol-emoji_sloth plugin-emoji-symbols-api', text: 'This is a sloth symbol'</code></li>
+        <li><code>addSummary icon: 'symbol-solid/flag-checkered plugin-font-awesome-api', text: 'This is a checkered flag from font-awesome. Note the slash between the icon family and the name.</code></li>
         <li><code>addSummary icon: 'symbol-cube', text: 'This is a Jenkins Core symbol'</code></li>
         <li><code>addSummary icon: 'icon-gear', text: 'This is a Jenkins Core icon'</code></li>
     </ul>


### PR DESCRIPTION
Added documentation to addBadge, addSummary on how to use font-awesome's plugin api. This is a repeat of PR #184, which regressed during a documentation refactor, but instead of only being mentioned in the README, actually includes examples in the API docs.

Original commit: 55e3f5a9f4547e26262f4cb54757bc56a97ab272
Refactor commit: fa18486e5f1f21f8f3eb7fe3a8e6088647e84ab3

### Testing done

These examples were pulled straight from my own Jenkinsfiles. No code was modified, only docs.

### Submitter checklist
- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
- [X ] Ensure you have provided tests - that demonstrates feature works or fixes the issue