### PR TITLE
Fix missing icons for legacy SVG icon names (issue #368)

### DIFF
--- a/src/main/java/com/jenkinsci/plugins/badge/action/AbstractBadgeAction.java
+++ b/src/main/java/com/jenkinsci/plugins/badge/action/AbstractBadgeAction.java
@@ -121,7 +121,7 @@ public abstract class AbstractBadgeAction implements Action, Serializable {
             return icon;
         }
 
-        // backwards compatible replacement for old GIFs - since 2.8
+        // backwards compatible replacement for old GIFs and SVGs - since 2.8
         return switch (icon) {
             case "completed.gif" -> "symbol-status-blue";
             case "db_in.gif" -> Ionicons.getIconClassName("cloud-upload-outline");
@@ -137,6 +137,10 @@ public abstract class AbstractBadgeAction implements Action, Serializable {
             case "text.gif" -> "symbol-document-text";
             case "warning.gif" -> "symbol-status-yellow";
             case "yellow.gif" -> Emojis.getIconClassName("yellow_square");
+            case "accept.svg" -> Ionicons.getIconClassName("checkmark-circle-outline");
+            case "error.svg" -> "symbol-status-red";
+            case "folder-delete.svg" -> Ionicons.getIconClassName("folder-open-outline");
+            case "warning.svg" -> "symbol-status-yellow";
             default -> {
                 if (isJenkinsResource(Jenkins.RESOURCE_PATH + "/images/16x16/" + icon)) {
                     yield Jenkins.RESOURCE_PATH + "/images/16x16/" + icon;

--- a/src/test/java/com/jenkinsci/plugins/badge/action/AbstractBadgeActionTest.java
+++ b/src/test/java/com/jenkinsci/plugins/badge/action/AbstractBadgeActionTest.java
@@ -131,9 +131,15 @@ abstract class AbstractBadgeActionTest {
         action.setIcon("blue.gif");
         assertThat(action.getIcon(), is(Jenkins.RESOURCE_PATH + "/images/16x16/blue.gif"));
 
-        // core resource in svgs
+        // backwards compatible replacement for old SVGs
+        action.setIcon("accept.svg");
+        assertThat(action.getIcon(), is(Ionicons.getIconClassName("checkmark-circle-outline")));
         action.setIcon("error.svg");
-        assertThat(action.getIcon(), is(Jenkins.RESOURCE_PATH + "/images/svgs/error.svg"));
+        assertThat(action.getIcon(), is("symbol-status-red"));
+        action.setIcon("folder-delete.svg");
+        assertThat(action.getIcon(), is(Ionicons.getIconClassName("folder-open-outline")));
+        action.setIcon("warning.svg");
+        assertThat(action.getIcon(), is("symbol-status-yellow"));
 
         // can not be validated
         action.setIcon("[/]");


### PR DESCRIPTION
## Description

Fixes #368 

Extends the backwards-compatible icon mapping in `AbstractBadgeAction.getIcon()` to cover four legacy SVG icon names that were previously falling through to the `default` branch and attempting a Jenkins resource path lookup. Those SVG files no longer exist in modern Jenkins installations, resulting in missing icons. The fix maps them to their modern symbol/Ionicons equivalents, consistent with how the existing GIF replacements (introduced in 2.8) work.

| Legacy icon | Replacement |
|---|---|
| `accept.svg` | `ion-checkmark-circle-outline` |
| `error.svg` | `symbol-status-red` |
| `folder-delete.svg` | `ion-folder-open-outline` |
| `warning.svg` | `symbol-status-yellow` |

The comment on the `switch` block is also updated from *"old GIFs"* to *"old GIFs and SVGs"* to accurately describe its scope.

### Testing done

Updated the existing `AbstractBadgeActionTest` to assert the new mappings. The previously passing assertion for `error.svg` (which expected the old Jenkins resource path) has been corrected to expect `symbol-status-red`, reflecting the actual desired behaviour. New assertions added for `accept.svg`, `folder-delete.svg`, and `warning.svg`. All tests pass via `mvn test`.

```
[INFO] Tests run: 184, Failures: 0, Errors: 0, Skipped: 1
[INFO] BUILD SUCCESS
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira — fixes #368
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed